### PR TITLE
http.TCPServer testing and spiked GET /

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,4 @@ $ tcpdump -i <interface> -s 0 -w gohttp--netcat-4.pcap #Capture
 $ tcpdump -4 <file> #View file
 ```
 
-
 There's also `curl --trace <hex as ascii dump file> ...`

--- a/backlog.md
+++ b/backlog.md
@@ -1,0 +1,16 @@
+# Developer backlog
+
+## Main
+
+- Handle Ctrl+C signal so it can exit with 0 instead of non-zero.
+
+
+## Request parsing
+
+RFC7230 Section 3.1.1
+
+- Should allow a request line of at least 8,000 octets.  On the flip side, prevent a
+  Denial of Service attack with a request line that (almost) never ends (has no CR).
+  In this case, it should only read up to 8,000 octets and give up if it hasn't seen CR yet.
+- I/O errors when reading from the socket.
+  Need to invest in a mock bufio.Reader that returns errors.

--- a/http/request.go
+++ b/http/request.go
@@ -8,33 +8,41 @@ import (
 const maxLengthOfFieldInRequestLine = 8000
 
 type RequestParser interface {
-	ParseRequest(reader *bufio.Reader) (Request, *ParseError)
+	ParseRequest(reader *bufio.Reader) (*Request, *ParseError)
 }
 
 type RFC7230RequestParser struct{}
 
-func (parser RFC7230RequestParser) ParseRequest(reader *bufio.Reader) (Request, *ParseError) {
-	method, _ := readFieldFromRequestLine(reader)
+func (parser RFC7230RequestParser) ParseRequest(reader *bufio.Reader) (*Request, *ParseError) {
+	method, _ := readFieldFromRequestLine(reader, ' ')
 	if len(method) == 0 {
 		return nil, &ParseError{StatusCode: 400, Reason: "Bad Request"}
 	} else if len(method) > maxLengthOfFieldInRequestLine {
 		return nil, &ParseError{StatusCode: 501, Reason: "Not Implemented"}
 	}
 
-	target, _ := readFieldFromRequestLine(reader)
+	target, _ := readFieldFromRequestLine(reader, ' ')
 	if len(target) > maxLengthOfFieldInRequestLine {
 		return nil, &ParseError{StatusCode: 414, Reason: "URI Too Long"}
 	}
 
-	return nil, nil
+	version, _ := readFieldFromRequestLine(reader, '\r')
+	return &Request{
+		Method:  method,
+		Target:  target,
+		Version: version,
+	}, nil
 }
 
-func readFieldFromRequestLine(reader *bufio.Reader) (string, error) {
-	field, err := reader.ReadString(' ')
-	return strings.TrimSuffix(field, " "), err
+func readFieldFromRequestLine(reader *bufio.Reader, delimiter byte) (string, error) {
+	field, err := reader.ReadString(delimiter)
+	return strings.TrimSuffix(field, string(delimiter)), err
 }
 
-type Request interface {
+type Request struct {
+	Method  string
+	Target  string
+	Version string
 }
 
 type ParseError struct {

--- a/http/request.go
+++ b/http/request.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	"bufio"
+	"strings"
+)
+
+const maxLengthOfFieldInRequestLine = 8000
+
+type RequestParser interface {
+	ParseRequest(reader *bufio.Reader) (Request, *ParseError)
+}
+
+type RFC7230RequestParser struct{}
+
+func (parser RFC7230RequestParser) ParseRequest(reader *bufio.Reader) (Request, *ParseError) {
+	method, _ := readFieldFromRequestLine(reader)
+	if len(method) == 0 {
+		return nil, &ParseError{StatusCode: 400, Reason: "Bad Request"}
+	} else if len(method) > maxLengthOfFieldInRequestLine {
+		return nil, &ParseError{StatusCode: 501, Reason: "Not Implemented"}
+	}
+
+	target, _ := readFieldFromRequestLine(reader)
+	if len(target) > maxLengthOfFieldInRequestLine {
+		return nil, &ParseError{StatusCode: 414, Reason: "URI Too Long"}
+	}
+
+	return nil, nil
+}
+
+func readFieldFromRequestLine(reader *bufio.Reader) (string, error) {
+	field, err := reader.ReadString(' ')
+	return strings.TrimSuffix(field, " "), err
+}
+
+type Request interface {
+}
+
+type ParseError struct {
+	StatusCode int
+	Reason     string
+}

--- a/http/request.go
+++ b/http/request.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 )
 
-const maxLengthOfFieldInRequestLine = 8000
-
 type RequestParser interface {
 	ParseRequest(reader *bufio.Reader) (*Request, *ParseError)
 }
@@ -26,8 +24,8 @@ func (parser RFC7230RequestParser) ParseRequest(reader *bufio.Reader) (*Request,
 	}
 
 	request := &Request{
-		Method: fields[0],
-		Target: fields[1],
+		Method:  fields[0],
+		Target:  fields[1],
 		Version: fields[2],
 	}
 
@@ -56,32 +54,6 @@ func readCRLFLine(reader *bufio.Reader) (string, error) {
 
 	trimmed := strings.TrimSuffix(maybeEndsInCR, "\r")
 	return trimmed, nil
-}
-
-func (parser RFC7230RequestParser) OldParseRequest(reader *bufio.Reader) (*Request, *ParseError) {
-	method, _ := readUpTo(reader, ' ')
-	if len(method) == 0 {
-		return nil, &ParseError{StatusCode: 400, Reason: "Bad Request"}
-	} else if len(method) > maxLengthOfFieldInRequestLine {
-		return nil, &ParseError{StatusCode: 501, Reason: "Not Implemented"}
-	}
-
-	target, _ := readUpTo(reader, ' ')
-	if len(target) > maxLengthOfFieldInRequestLine {
-		return nil, &ParseError{StatusCode: 414, Reason: "URI Too Long"}
-	}
-
-	version, _ := readUpTo(reader, '\r')
-	return &Request{
-		Method:  method,
-		Target:  target,
-		Version: version,
-	}, nil
-}
-
-func readUpTo(reader *bufio.Reader, delimiter byte) (string, error) {
-	field, err := reader.ReadString(delimiter)
-	return strings.TrimSuffix(field, string(delimiter)), err
 }
 
 type Request struct {

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -11,6 +11,60 @@ import (
 )
 
 var _ = Describe("RFC7230RequestParser", func() {
+	FDescribe("#ParseRequest", func() {
+		var (
+			parser  *http.RFC7230RequestParser
+			request *http.Request
+			err     *http.ParseError
+		)
+
+		BeforeEach(func() {
+			parser = &http.RFC7230RequestParser{}
+		})
+
+		XIt("playground", func() {
+			buffer := bytes.NewBufferString("abcd")
+			bufioReader := bufio.NewReader(buffer)
+
+			firstRound, firstReadErr := bufioReader.ReadString('b')
+			for i, c := range firstRound {
+				fmt.Printf("FIRST ROUND Byte %02d: %02x %2s\n", i, c, string(c))
+			}
+			if firstReadErr != nil {
+				fmt.Printf("First round %s\n", firstReadErr.Error())
+			}
+
+			secondRound, secondReadErr := bufioReader.ReadString('e')
+			for i, c := range secondRound {
+				fmt.Printf("SECOND ROUND Byte %02d: %02x %2s\n", i, c, string(c))
+			}
+			if secondReadErr != nil {
+				fmt.Printf("Second round %s\n", secondReadErr.Error())
+			}
+		})
+
+		It("parses a well-formed request", func() {
+			request, err = parser.ParseRequest(makeReader("GET / HTTP/1.1\r\n\r\n"))
+			Expect(request).To(BeEquivalentTo(&http.Request{
+				Method:  "GET",
+				Target:  "/",
+				Version: "HTTP/1.1",
+			}))
+		})
+
+		It("returns 400 Bad Request for an empty request", func() {
+			buffer := bytes.NewBufferString("")
+			request, err = parser.ParseRequest(bufio.NewReader(buffer))
+			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+		})
+
+		It("returns 400 Bad Request for a request not containing 3 fields in the request line", func() {
+			buffer := bytes.NewBufferString("\r\n")
+			request, err = parser.ParseRequest(bufio.NewReader(buffer))
+			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+		})
+	})
+
 	Describe("#ParseRequest", func() {
 		var (
 			parser  http.RequestParser

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -53,6 +53,18 @@ var _ = Describe("RFC7230RequestParser", func() {
 			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 		})
 
+		It("returns 400 Bad Request when multiple spaces are separating fields in request-line", func() {
+			buffer := bytes.NewBufferString("GET /  HTTP/1.1\r\n\r\n")
+			request, err = parser.ParseRequest(bufio.NewReader(buffer))
+			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+		})
+
+		It("returns 400 Bad Request when fields in request-line contain spaces", func() {
+			buffer := bytes.NewBufferString("GET /a\\ b HTTP/1.1\r\n\r\n")
+			request, err = parser.ParseRequest(bufio.NewReader(buffer))
+			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+		})
+
 		Context("given a well-formed request", func() {
 			BeforeEach(func() {
 				buffer := bytes.NewBufferString("GET /foo HTTP/1.1\r\nAccept: */*\r\n\r\n")
@@ -70,16 +82,10 @@ var _ = Describe("RFC7230RequestParser", func() {
 			It("returns no error", func() {
 				Expect(err).To(BeNil())
 			})
-			It("parses CRLF lines until reaching a line with only CRLF", func() {
+			It("reads the entire request until reaching a line with only CRLF", func() {
 				Expect(reader.Buffered()).To(Equal(0))
 			})
 		})
-
-		//It("returns 400 Bad Request for a request not containing 3 fields in the request line", func() {
-		//	buffer := bytes.NewBufferString("")
-		//	request, err = parser.ParseRequest(bufio.NewReader(buffer))
-		//	Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
-		//})
 	})
 
 	XDescribe("#OldParseRequest", func() {

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -1,0 +1,48 @@
+package http_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"strings"
+	"fmt"
+	"github.com/kkrull/gohttp/http"
+	"bytes"
+	"bufio"
+)
+
+var _ = Describe("RFC7230RequestParser", func() {
+	var parser http.RequestParser
+	BeforeEach(func() {
+		parser = http.RFC7230RequestParser{}
+	})
+
+	Context("when the request starts with whitespace", func() {
+		It("Responds 400 Bad Request", func() {
+			_, err := parser.ParseRequest(makeReader(" GET / HTTP/1.1\r\n\r\n"))
+			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+		})
+	})
+
+	Context("when the request method is longer than 8,000 octets", func() {
+		It("responds 501 Not Implemented", func() {
+			enormousMethod := strings.Repeat("POST", 2000) + "!"
+			_, err := parser.ParseRequest(makeReader(fmt.Sprintf("%s / HTTP/1.1\r\n\r\n", enormousMethod)))
+			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 501, Reason: "Not Implemented"}))
+		})
+	})
+
+	Context("when the request target is longer than 8,000 octets", func() {
+		It("responds 414 URI Too Long", func() {
+			enormousTarget := strings.Repeat("/foo", 2000) + "/"
+			_, err := parser.ParseRequest(makeReader(fmt.Sprintf("GET %s HTTP/1.1\r\n\r\n", enormousTarget)))
+			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 414, Reason: "URI Too Long"}))
+		})
+	})
+
+	XIt("Section 3 paragraph 3 (encoding must be a superset of US-ASCII)")
+	XIt("Section 3 paragraph 5 (recipient must reject request with whitespace between the start-line and the first header)")
+})
+
+func makeReader(text string) *bufio.Reader {
+	return bufio.NewReader(bytes.NewBufferString(text))
+}

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var _ = Describe("RFC7230RequestParser", func() {
-	FDescribe("#ParseRequest", func() {
+	Describe("#ParseRequest", func() {
 		var (
 			parser  *http.RFC7230RequestParser
 			reader  *bufio.Reader
@@ -21,36 +21,6 @@ var _ = Describe("RFC7230RequestParser", func() {
 
 		BeforeEach(func() {
 			parser = &http.RFC7230RequestParser{}
-		})
-
-		XIt("playground", func() {
-			buffer := bytes.NewBufferString("abcd")
-			bufioReader := bufio.NewReader(buffer)
-
-			firstRound, firstReadErr := bufioReader.ReadString('b')
-			for i, c := range firstRound {
-				fmt.Printf("FIRST ROUND Byte %02d: %02x %2s\n", i, c, string(c))
-			}
-			if firstReadErr != nil {
-				fmt.Printf("First round %s\n", firstReadErr.Error())
-			}
-
-			secondRound, secondReadErr := bufioReader.ReadString('e')
-			for i, c := range secondRound {
-				fmt.Printf("SECOND ROUND Byte %02d: %02x %2s\n", i, c, string(c))
-			}
-			if secondReadErr != nil {
-				fmt.Printf("Second round %s\n", secondReadErr.Error())
-			}
-		})
-
-		XIt("parses a well-formed request without headers or a body", func() {
-			request, err = parser.ParseRequest(makeReader("GET / HTTP/1.1\r\n\r\n"))
-			Expect(request).To(BeEquivalentTo(&http.Request{
-				Method:  "GET",
-				Target:  "/",
-				Version: "HTTP/1.1",
-			}))
 		})
 
 		It("returns 400 Bad Request for a completely blank request", func() {
@@ -85,13 +55,17 @@ var _ = Describe("RFC7230RequestParser", func() {
 
 		Context("given a well-formed request", func() {
 			BeforeEach(func() {
-				buffer := bytes.NewBufferString("GET / HTTP/1.1\r\nAccept: */*\r\n\r\n")
+				buffer := bytes.NewBufferString("GET /foo HTTP/1.1\r\nAccept: */*\r\n\r\n")
 				reader = bufio.NewReader(buffer)
 				request, err = parser.ParseRequest(reader)
 			})
 
-			FIt("parses the request", func() {
-				Expect(request).NotTo(BeNil())
+			It("parses the request", func() {
+				Expect(request).To(BeEquivalentTo(&http.Request{
+					Method:  "GET",
+					Target:  "/foo",
+					Version: "HTTP/1.1",
+				}))
 			})
 			It("returns no error", func() {
 				Expect(err).To(BeNil())
@@ -108,7 +82,7 @@ var _ = Describe("RFC7230RequestParser", func() {
 		//})
 	})
 
-	Describe("#ParseRequest", func() {
+	XDescribe("#OldParseRequest", func() {
 		var (
 			parser  http.RequestParser
 			request *http.Request

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -43,7 +43,7 @@ var _ = Describe("RFC7230RequestParser", func() {
 			}
 		})
 
-		It("parses a well-formed request", func() {
+		XIt("parses a well-formed request without headers or a body", func() {
 			request, err = parser.ParseRequest(makeReader("GET / HTTP/1.1\r\n\r\n"))
 			Expect(request).To(BeEquivalentTo(&http.Request{
 				Method:  "GET",
@@ -52,14 +52,26 @@ var _ = Describe("RFC7230RequestParser", func() {
 			}))
 		})
 
-		It("returns 400 Bad Request for an empty request", func() {
+		//It("returns 400 Bad Request for a request not containing 3 fields in the request line", func() {
+		//	buffer := bytes.NewBufferString("")
+		//	request, err = parser.ParseRequest(bufio.NewReader(buffer))
+		//	Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+		//})
+
+		It("returns 400 Bad Request for a completely blank request", func() {
 			buffer := bytes.NewBufferString("")
 			request, err = parser.ParseRequest(bufio.NewReader(buffer))
 			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 		})
 
-		It("returns 400 Bad Request for a request not containing 3 fields in the request line", func() {
-			buffer := bytes.NewBufferString("\r\n")
+		It("returns 400 Bad Request for a request line missing CR", func() {
+			buffer := bytes.NewBufferString("\n")
+			request, err = parser.ParseRequest(bufio.NewReader(buffer))
+			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+		})
+
+		It("returns 400 Bad Request for a request line missing LF", func() {
+			buffer := bytes.NewBufferString("\r")
 			request, err = parser.ParseRequest(bufio.NewReader(buffer))
 			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 		})

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"bufio"
 	"github.com/kkrull/gohttp/http"
-	"strings"
 )
 
 var _ = Describe("RFC7230RequestParser", func() {
@@ -23,46 +22,53 @@ var _ = Describe("RFC7230RequestParser", func() {
 			parser = &http.RFC7230RequestParser{}
 		})
 
-		It("returns 400 Bad Request for a completely blank request", func() {
-			buffer := bytes.NewBufferString("")
-			request, err = parser.ParseRequest(bufio.NewReader(buffer))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
-		})
+		Describe("it returns 400 Bad Request", func() {
+			It("for a completely blank request", func() {
+				buffer := bytes.NewBufferString("")
+				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+			})
 
-		It("returns 400 Bad Request for any line missing CR", func() {
-			buffer := bytes.NewBufferString("GET / HTTP/1.1\r\n\n")
-			request, err = parser.ParseRequest(bufio.NewReader(buffer))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
-		})
+			It("for any line missing CR", func() {
+				buffer := bytes.NewBufferString("GET / HTTP/1.1\r\n\n")
+				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+			})
 
-		It("returns 400 Bad Request for any line missing LF", func() {
-			buffer := bytes.NewBufferString("GET / HTTP/1.1\r")
-			request, err = parser.ParseRequest(bufio.NewReader(buffer))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
-		})
+			It("for any line missing LF", func() {
+				buffer := bytes.NewBufferString("GET / HTTP/1.1\r")
+				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+			})
 
-		It("returns 400 Bad Request for a request missing a request-line", func() {
-			buffer := bytes.NewBufferString("\r\n")
-			request, err = parser.ParseRequest(bufio.NewReader(buffer))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
-		})
+			It("for a request missing a request-line", func() {
+				buffer := bytes.NewBufferString("\r\n")
+				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+			})
 
-		It("returns 400 Bad Request for a request missing an ending CRLF", func() {
-			buffer := bytes.NewBufferString("GET / HTTP/1.1\r\n")
-			request, err = parser.ParseRequest(bufio.NewReader(buffer))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
-		})
+			It("for a request missing an ending CRLF", func() {
+				buffer := bytes.NewBufferString("GET / HTTP/1.1\r\n")
+				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+			})
 
-		It("returns 400 Bad Request when multiple spaces are separating fields in request-line", func() {
-			buffer := bytes.NewBufferString("GET /  HTTP/1.1\r\n\r\n")
-			request, err = parser.ParseRequest(bufio.NewReader(buffer))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
-		})
+			It("when multiple spaces are separating fields in request-line", func() {
+				buffer := bytes.NewBufferString("GET /  HTTP/1.1\r\n\r\n")
+				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+			})
 
-		It("returns 400 Bad Request when fields in request-line contain spaces", func() {
-			buffer := bytes.NewBufferString("GET /a\\ b HTTP/1.1\r\n\r\n")
-			request, err = parser.ParseRequest(bufio.NewReader(buffer))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+			It("when fields in request-line contain spaces", func() {
+				buffer := bytes.NewBufferString("GET /a\\ b HTTP/1.1\r\n\r\n")
+				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+			})
+
+			It("when the request starts with whitespace", func() {
+				request, err = parser.ParseRequest(makeReader(" GET / HTTP/1.1\r\n\r\n"))
+				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+			})
 		})
 
 		Context("given a well-formed request", func() {
@@ -79,59 +85,13 @@ var _ = Describe("RFC7230RequestParser", func() {
 					Version: "HTTP/1.1",
 				}))
 			})
+
 			It("returns no error", func() {
 				Expect(err).To(BeNil())
 			})
+			
 			It("reads the entire request until reaching a line with only CRLF", func() {
 				Expect(reader.Buffered()).To(Equal(0))
-			})
-		})
-	})
-
-	XDescribe("#OldParseRequest", func() {
-		var (
-			parser  http.RequestParser
-			request *http.Request
-			err     *http.ParseError
-		)
-
-		BeforeEach(func() {
-			parser = http.RFC7230RequestParser{}
-		})
-
-		Describe("Section 3.1.1", func() {
-			Context("given a well formed request line that is not too long", func() {
-				It("parses the HTTP method as all text before the first space", func() {
-					request, err = parser.ParseRequest(makeReader("GET / HTTP/1.1\r\n\r\n"))
-					Expect(request).To(BeEquivalentTo(&http.Request{
-						Method:  "GET",
-						Target:  "/",
-						Version: "HTTP/1.1",
-					}))
-				})
-			})
-
-			Context("when the request starts with whitespace", func() {
-				It("Returns 400 Bad Request", func() {
-					request, err = parser.ParseRequest(makeReader(" GET / HTTP/1.1\r\n\r\n"))
-					Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
-				})
-			})
-
-			Context("when the request method is longer than 8,000 octets", func() {
-				It("Returns 501 Not Implemented", func() {
-					enormousMethod := strings.Repeat("POST", 2000) + "!"
-					request, err = parser.ParseRequest(makeReader("%s / HTTP/1.1\r\n\r\n", enormousMethod))
-					Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 501, Reason: "Not Implemented"}))
-				})
-			})
-
-			Context("when the request target is longer than 8,000 octets", func() {
-				It("Returns 414 URI Too Long", func() {
-					enormousTarget := strings.Repeat("/foo", 2000) + "/"
-					request, err = parser.ParseRequest(makeReader("GET %s HTTP/1.1\r\n\r\n", enormousTarget))
-					Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 414, Reason: "URI Too Long"}))
-				})
 			})
 		})
 	})

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -3,46 +3,64 @@ package http_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"strings"
 	"fmt"
-	"github.com/kkrull/gohttp/http"
 	"bytes"
 	"bufio"
+	"github.com/kkrull/gohttp/http"
+	"strings"
 )
 
 var _ = Describe("RFC7230RequestParser", func() {
-	var parser http.RequestParser
-	BeforeEach(func() {
-		parser = http.RFC7230RequestParser{}
-	})
+	Describe("#ParseRequest", func() {
+		var (
+			parser  http.RequestParser
+			request *http.Request
+			err     *http.ParseError
+		)
 
-	Context("when the request starts with whitespace", func() {
-		It("Responds 400 Bad Request", func() {
-			_, err := parser.ParseRequest(makeReader(" GET / HTTP/1.1\r\n\r\n"))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+		BeforeEach(func() {
+			parser = http.RFC7230RequestParser{}
+		})
+
+		Describe("Section 3.1.1", func() {
+			Context("given a well formed request line that is not too long", func() {
+				It("parses the HTTP method as all text before the first space", func() {
+					request, err = parser.ParseRequest(makeReader("GET / HTTP/1.1\r\n\r\n"))
+					Expect(request).To(BeEquivalentTo(&http.Request{
+						Method:  "GET",
+						Target:  "/",
+						Version: "HTTP/1.1",
+					}))
+				})
+			})
+
+			Context("when the request starts with whitespace", func() {
+				It("Returns 400 Bad Request", func() {
+					request, err = parser.ParseRequest(makeReader(" GET / HTTP/1.1\r\n\r\n"))
+					Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
+				})
+			})
+
+			Context("when the request method is longer than 8,000 octets", func() {
+				It("Returns 501 Not Implemented", func() {
+					enormousMethod := strings.Repeat("POST", 2000) + "!"
+					request, err = parser.ParseRequest(makeReader("%s / HTTP/1.1\r\n\r\n", enormousMethod))
+					Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 501, Reason: "Not Implemented"}))
+				})
+			})
+
+			Context("when the request target is longer than 8,000 octets", func() {
+				It("Returns 414 URI Too Long", func() {
+					enormousTarget := strings.Repeat("/foo", 2000) + "/"
+					request, err = parser.ParseRequest(makeReader("GET %s HTTP/1.1\r\n\r\n", enormousTarget))
+					Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 414, Reason: "URI Too Long"}))
+				})
+			})
 		})
 	})
-
-	Context("when the request method is longer than 8,000 octets", func() {
-		It("responds 501 Not Implemented", func() {
-			enormousMethod := strings.Repeat("POST", 2000) + "!"
-			_, err := parser.ParseRequest(makeReader(fmt.Sprintf("%s / HTTP/1.1\r\n\r\n", enormousMethod)))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 501, Reason: "Not Implemented"}))
-		})
-	})
-
-	Context("when the request target is longer than 8,000 octets", func() {
-		It("responds 414 URI Too Long", func() {
-			enormousTarget := strings.Repeat("/foo", 2000) + "/"
-			_, err := parser.ParseRequest(makeReader(fmt.Sprintf("GET %s HTTP/1.1\r\n\r\n", enormousTarget)))
-			Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 414, Reason: "URI Too Long"}))
-		})
-	})
-
-	XIt("Section 3 paragraph 3 (encoding must be a superset of US-ASCII)")
-	XIt("Section 3 paragraph 5 (recipient must reject request with whitespace between the start-line and the first header)")
 })
 
-func makeReader(text string) *bufio.Reader {
+func makeReader(template string, values ...string) *bufio.Reader {
+	text := fmt.Sprintf(template, values)
 	return bufio.NewReader(bytes.NewBufferString(text))
 }

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -24,44 +24,37 @@ var _ = Describe("RFC7230RequestParser", func() {
 
 		Describe("it returns 400 Bad Request", func() {
 			It("for a completely blank request", func() {
-				buffer := bytes.NewBufferString("")
-				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				request, err = parser.ParseRequest(makeReader(""))
 				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 			})
 
 			It("for any line missing CR", func() {
-				buffer := bytes.NewBufferString("GET / HTTP/1.1\r\n\n")
-				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				request, err = parser.ParseRequest(makeReader("GET / HTTP/1.1\r\n\n"))
 				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 			})
 
 			It("for any line missing LF", func() {
-				buffer := bytes.NewBufferString("GET / HTTP/1.1\r")
-				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				request, err = parser.ParseRequest(makeReader("GET / HTTP/1.1\r"))
 				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 			})
 
 			It("for a request missing a request-line", func() {
-				buffer := bytes.NewBufferString("\r\n")
-				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				request, err = parser.ParseRequest(makeReader("\r\n"))
 				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 			})
 
 			It("for a request missing an ending CRLF", func() {
-				buffer := bytes.NewBufferString("GET / HTTP/1.1\r\n")
-				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				request, err = parser.ParseRequest(makeReader("GET / HTTP/1.1\r\n"))
 				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 			})
 
 			It("when multiple spaces are separating fields in request-line", func() {
-				buffer := bytes.NewBufferString("GET /  HTTP/1.1\r\n\r\n")
-				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				request, err = parser.ParseRequest(makeReader("GET /  HTTP/1.1\r\n\r\n"))
 				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 			})
 
 			It("when fields in request-line contain spaces", func() {
-				buffer := bytes.NewBufferString("GET /a\\ b HTTP/1.1\r\n\r\n")
-				request, err = parser.ParseRequest(bufio.NewReader(buffer))
+				request, err = parser.ParseRequest(makeReader("GET /a\\ b HTTP/1.1\r\n\r\n"))
 				Expect(err).To(BeEquivalentTo(&http.ParseError{StatusCode: 400, Reason: "Bad Request"}))
 			})
 

--- a/http/server.go
+++ b/http/server.go
@@ -77,18 +77,18 @@ func (server TCPServer) acceptConnections() {
 			return
 		}
 
-		handleConnection(conn)
+		_ = handleConnection(conn)
 	}
 }
 
-func handleConnection(conn *net.TCPConn) {
+func handleConnection(conn *net.TCPConn) error {
 	_, err := readSocket(conn)
 	if err != nil {
-		return
+		return err
 	}
 
 	fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")
-	_ = conn.Close()
+	return conn.Close()
 }
 
 func readSocket(conn *net.TCPConn) (*bytes.Buffer, error) {

--- a/http/server.go
+++ b/http/server.go
@@ -85,7 +85,6 @@ func (server TCPServer) acceptConnections() {
 
 func (server TCPServer) handleConnection(conn *net.TCPConn) {
 	reader := bufio.NewReader(conn)
-	//parser := RFC7230RequestParser{}
 	_, parseError := server.Parser.ParseRequest(reader)
 	if parseError != nil {
 		fmt.Fprintf(conn, "HTTP/1.1 %d %s\r\n", parseError.StatusCode, parseError.Reason)

--- a/http/server.go
+++ b/http/server.go
@@ -91,6 +91,12 @@ func handleConnection(conn *net.TCPConn) {
 		return
 	}
 
+	targetBytes, _ := reader.ReadBytes(' ')
+	if len(targetBytes) > 8000 {
+		fmt.Fprint(conn, "HTTP/1.1 414 URI Too Long\r\n")
+		return
+	}
+
 	remainingBytes := make([]byte, 1024)
 	_, _ = reader.Read(remainingBytes)
 	fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")

--- a/http/server.go
+++ b/http/server.go
@@ -91,8 +91,6 @@ func (server TCPServer) handleConnection(conn *net.TCPConn) {
 		return
 	}
 
-	remainingBytes := make([]byte, 1024)
-	_, _ = reader.Read(remainingBytes)
 	fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")
 }
 

--- a/http/server.go
+++ b/http/server.go
@@ -86,8 +86,9 @@ func handleConnection(conn *net.TCPConn) {
 	if len(methodBytes) == 1 {
 		fmt.Fprint(conn, "HTTP/1.1 400 Bad Request\r\n")
 		return
-	} else {
-		fmt.Printf("Method: <%s>\n", methodBytes)
+	} else if len(methodBytes) > 8000 {
+		fmt.Fprint(conn, "HTTP/1.1 501 Not Implemented\r\n")
+		return
 	}
 
 	remainingBytes := make([]byte, 1024)

--- a/http/server.go
+++ b/http/server.go
@@ -85,13 +85,22 @@ func (server TCPServer) acceptConnections() {
 
 func (server TCPServer) handleConnection(conn *net.TCPConn) {
 	reader := bufio.NewReader(conn)
-	_, parseError := server.Parser.ParseRequest(reader)
+	request, parseError := server.Parser.ParseRequest(reader)
 	if parseError != nil {
 		fmt.Fprintf(conn, "HTTP/1.1 %d %s\r\n", parseError.StatusCode, parseError.Reason)
 		return
 	}
 
-	fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")
+	switch request.Target {
+	case "/":
+		fmt.Fprint(conn, "HTTP/1.1 200 OK\r\n")
+		fmt.Fprint(conn, "Content-Length: 5\r\n")
+		fmt.Fprint(conn, "Content-Type: text/plain\r\n")
+		fmt.Fprint(conn, "\r\n")
+		fmt.Fprintf(conn, "hello")
+	default:
+		fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")
+	}
 }
 
 func (server *TCPServer) Shutdown() error {

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -5,10 +5,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/kkrull/gohttp/http"
 	"net"
-	"bufio"
-	"io"
 	"bytes"
 	"github.com/kkrull/gohttp/mock"
+	"io/ioutil"
 )
 
 var (
@@ -234,18 +233,8 @@ func expectHttpResponse(conn net.Conn) {
 }
 
 func readString(conn net.Conn) (string, error) {
-	runes := make([]rune, 0)
-	reader := bufio.NewReader(conn)
-	for {
-		r, _, readErr := reader.ReadRune()
-		if readErr == io.EOF {
-			return string(runes), nil
-		} else if readErr != nil {
-			return "", readErr
-		} else {
-			runes = append(runes, r)
-		}
-	}
+	readBytes, err := ioutil.ReadAll(conn)
+	return string(readBytes), err
 }
 
 func writeString(conn net.Conn, s string) {

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -204,7 +204,7 @@ var _ = Describe("TCPServer", func() {
 				conn, connectError = net.Dial("tcp", server.Address().String())
 				Expect(connectError).NotTo(HaveOccurred())
 
-				enormousMethod := strings.Repeat("POST", 2000)
+				enormousMethod := strings.Repeat("POST", 2000) + "!"
 				writeString(conn, fmt.Sprintf("%s / HTTP/1.1\r\n\r\n", enormousMethod))
 				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 501 Not Implemented\r\n"))
 				close(done)
@@ -216,7 +216,7 @@ var _ = Describe("TCPServer", func() {
 				conn, connectError = net.Dial("tcp", server.Address().String())
 				Expect(connectError).NotTo(HaveOccurred())
 
-				enormousTarget := strings.Repeat("/foo", 2000)
+				enormousTarget := strings.Repeat("/foo", 2000) + "/"
 				writeString(conn, fmt.Sprintf("GET %s HTTP/1.1\r\n\r\n", enormousTarget))
 				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 414 URI Too Long\r\n"))
 				close(done)

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -123,29 +123,6 @@ var _ = Describe("TCPServer", func() {
 				Expect(tcpAddress.Port).To(BeNumerically("<=", 1<<16))
 			})
 		})
-
-		Context("when listening", func() {
-			BeforeEach(func() {
-				server = http.MakeTCPServerOnAvailablePort(contentRoot, "localhost")
-				Expect(server.Start()).To(Succeed())
-			})
-
-			It("responds to HTTP requests", func(done Done) {
-				for i := 0; i < 2; i++ {
-					conn, connectError = net.Dial("tcp", server.Address().String())
-					Expect(connectError).NotTo(HaveOccurred())
-					writeString(conn, "GET / HTTP/1.1\r\n\r\n")
-					expectHttpResponse(conn)
-				}
-
-				close(done)
-			})
-
-			XIt("Notifies of read errors, caused by Conn#SetReadDeadline")
-			XIt("Section 3.1.1 (recommended to allow request lines to be at least 8,000 octets)")
-			XIt("Section 3 paragraph 3 (encoding must be a superset of US-ASCII)")
-			XIt("Section 3 paragraph 5 (recipient must reject request with whitespace between the start-line and the first header)")
-		})
 	})
 
 	Describe("#Shutdown", func() {
@@ -182,6 +159,29 @@ var _ = Describe("TCPServer", func() {
 				close(done)
 			})
 		})
+	})
+
+	Context("when the server is running", func() {
+		BeforeEach(func() {
+			server = http.MakeTCPServerOnAvailablePort(contentRoot, "localhost")
+			Expect(server.Start()).To(Succeed())
+		})
+		
+		It("responds to HTTP requests", func(done Done) {
+			for i := 0; i < 2; i++ {
+				conn, connectError = net.Dial("tcp", server.Address().String())
+				Expect(connectError).NotTo(HaveOccurred())
+				writeString(conn, "GET / HTTP/1.1\r\n\r\n")
+				expectHttpResponse(conn)
+			}
+
+			close(done)
+		})
+
+		XIt("Notifies of read errors, caused by Conn#SetReadDeadline")
+		XIt("Section 3.1.1 (recommended to allow request lines to be at least 8,000 octets)")
+		XIt("Section 3 paragraph 3 (encoding must be a superset of US-ASCII)")
+		XIt("Section 3 paragraph 5 (recipient must reject request with whitespace between the start-line and the first header)")
 	})
 })
 

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -185,7 +185,7 @@ var _ = Describe("TCPServer", func() {
 
 		Context("when it receives a request", func() {
 			BeforeEach(func(done Done) {
-				parser = &mock.RequestParser{}
+				parser = &mock.RequestParser{ReturnsRequest: &http.Request{}}
 				server = &http.TCPServer{
 					Host:   "localhost",
 					Parser: parser}
@@ -207,7 +207,7 @@ var _ = Describe("TCPServer", func() {
 		Context("when the request parser returns an error", func() {
 			BeforeEach(func(done Done) {
 				parser = &mock.RequestParser{
-					ParseRequestReturnError: &http.ParseError{StatusCode: 400, Reason: "Bad Request"}}
+					ReturnsError: &http.ParseError{StatusCode: 400, Reason: "Bad Request"}}
 				server = &http.TCPServer{
 					Host:   "localhost",
 					Parser: parser}

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -77,10 +77,11 @@ var _ = Describe("TCPServer", func() {
 
 		Context("when there is an error resolving the given host and port to an address", func() {
 			It("immediately returns an error", func(done Done) {
-				server = http.MakeTCPServerOnAvailablePort(contentRoot, "bogus")
-				Expect(server.Start()).To(MatchError("lookup bogus: no such host"))
+				invalidHostAddress := "666.666.666.666"
+				server = http.MakeTCPServerOnAvailablePort(contentRoot, invalidHostAddress)
+				Expect(server.Start()).To(MatchError(HaveSuffix("no such host")))
 				close(done)
-			})
+			}, 5)
 		})
 
 		Context("when there is an error binding to resolved address", func() {

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -140,6 +140,11 @@ var _ = Describe("TCPServer", func() {
 
 				close(done)
 			})
+
+			XIt("Notifies of read errors, caused by Conn#SetReadDeadline")
+			XIt("Section 3.1.1 (recommended to allow request lines to be at least 8,000 octets)")
+			XIt("Section 3 paragraph 3 (encoding must be a superset of US-ASCII)")
+			XIt("Section 3 paragraph 5 (recipient must reject request with whitespace between the start-line and the first header)")
 		})
 	})
 

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -75,7 +75,7 @@ var _ = Describe("TCPServer", func() {
 			})
 		})
 
-		XContext("when there is an error resolving the given host and port to an address", func() {
+		Context("when there is an error resolving the given host and port to an address", func() {
 			It("immediately returns an error", func(done Done) {
 				invalidHostAddress := "666.666.666.666"
 				server = http.MakeTCPServerOnAvailablePort(contentRoot, invalidHostAddress)

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -189,27 +189,40 @@ var _ = Describe("TCPServer", func() {
 		})
 
 		Context("when the request starts with whitespace", func() {
-			It("Responds 400 Bad Request", func() {
+			It("Responds 400 Bad Request", func(done Done) {
 				conn, connectError = net.Dial("tcp", server.Address().String())
 				Expect(connectError).NotTo(HaveOccurred())
 
 				writeString(conn, " GET / HTTP/1.1\r\n\r\n")
 				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 400 Bad Request\r\n"))
+				close(done)
 			})
 		})
 		
 		Context("when the request method is longer than 8,000 octets", func() {
-			It("responds 501 Not Implemented", func() {
+			It("responds 501 Not Implemented", func(done Done) {
 				conn, connectError = net.Dial("tcp", server.Address().String())
 				Expect(connectError).NotTo(HaveOccurred())
 
-				nefariousHTTPMethod := strings.Repeat("POST", 2000)
-				writeString(conn, fmt.Sprintf("%s / HTTP/1.1\r\n\r\n", nefariousHTTPMethod))
+				enormousMethod := strings.Repeat("POST", 2000)
+				writeString(conn, fmt.Sprintf("%s / HTTP/1.1\r\n\r\n", enormousMethod))
 				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 501 Not Implemented\r\n"))
+				close(done)
 			})
 		})
 
-		XIt("Section 3.1.1 (recommended to allow request lines to be at least 8,000 octets)")
+		Context("when the request target is longer than 8,000 octets", func() {
+			It("responds 414 URI Too Long", func(done Done) {
+				conn, connectError = net.Dial("tcp", server.Address().String())
+				Expect(connectError).NotTo(HaveOccurred())
+
+				enormousTarget := strings.Repeat("/foo", 2000)
+				writeString(conn, fmt.Sprintf("GET %s HTTP/1.1\r\n\r\n", enormousTarget))
+				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 414 URI Too Long\r\n"))
+				close(done)
+			})
+		})
+
 		XIt("Section 3 paragraph 3 (encoding must be a superset of US-ASCII)")
 		XIt("Section 3 paragraph 5 (recipient must reject request with whitespace between the start-line and the first header)")
 	})
@@ -228,6 +241,7 @@ func readString(conn net.Conn) (string, error) {
 		if readErr == io.EOF {
 			return string(runes), nil
 		} else if readErr != nil {
+			fmt.Printf("Error reading: %s\n", readErr)
 			return "", readErr
 		} else {
 			runes = append(runes, r)

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -123,6 +123,24 @@ var _ = Describe("TCPServer", func() {
 				Expect(tcpAddress.Port).To(BeNumerically("<=", 1<<16))
 			})
 		})
+
+		Context("when the server is running", func() {
+			BeforeEach(func() {
+				server = http.MakeTCPServerOnAvailablePort(contentRoot, "localhost")
+				Expect(server.Start()).To(Succeed())
+			})
+
+			It("responds to HTTP requests", func(done Done) {
+				for i := 0; i < 2; i++ {
+					conn, connectError = net.Dial("tcp", server.Address().String())
+					Expect(connectError).NotTo(HaveOccurred())
+					writeString(conn, "GET / HTTP/1.1\r\n\r\n")
+					expectHttpResponse(conn)
+				}
+
+				close(done)
+			})
+		})
 	})
 
 	Describe("#Shutdown", func() {
@@ -161,24 +179,22 @@ var _ = Describe("TCPServer", func() {
 		})
 	})
 
-	Context("when the server is running", func() {
+	Describe("RFC 7230 Section 3.1.1: request-line", func() {
 		BeforeEach(func() {
 			server = http.MakeTCPServerOnAvailablePort(contentRoot, "localhost")
 			Expect(server.Start()).To(Succeed())
 		})
-		
-		It("responds to HTTP requests", func(done Done) {
-			for i := 0; i < 2; i++ {
+
+		Context("when the request starts with whitespace", func() {
+			It("Responds 400 Bad Request", func() {
 				conn, connectError = net.Dial("tcp", server.Address().String())
 				Expect(connectError).NotTo(HaveOccurred())
-				writeString(conn, "GET / HTTP/1.1\r\n\r\n")
-				expectHttpResponse(conn)
-			}
 
-			close(done)
+				writeString(conn, " GET / HTTP/1.1\r\n\r\n")
+				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 400 Bad Request\r\n"))
+			})
 		})
 
-		XIt("Notifies of read errors, caused by Conn#SetReadDeadline")
 		XIt("Section 3.1.1 (recommended to allow request lines to be at least 8,000 octets)")
 		XIt("Section 3 paragraph 3 (encoding must be a superset of US-ASCII)")
 		XIt("Section 3 paragraph 5 (recipient must reject request with whitespace between the start-line and the first header)")

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -8,6 +8,8 @@ import (
 	"bufio"
 	"io"
 	"bytes"
+	"strings"
+	"fmt"
 )
 
 var (
@@ -75,7 +77,7 @@ var _ = Describe("TCPServer", func() {
 			})
 		})
 
-		Context("when there is an error resolving the given host and port to an address", func() {
+		XContext("when there is an error resolving the given host and port to an address", func() {
 			It("immediately returns an error", func(done Done) {
 				invalidHostAddress := "666.666.666.666"
 				server = http.MakeTCPServerOnAvailablePort(contentRoot, invalidHostAddress)
@@ -193,6 +195,17 @@ var _ = Describe("TCPServer", func() {
 
 				writeString(conn, " GET / HTTP/1.1\r\n\r\n")
 				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 400 Bad Request\r\n"))
+			})
+		})
+		
+		Context("when the request method is longer than 8,000 octets", func() {
+			It("responds 501 Not Implemented", func() {
+				conn, connectError = net.Dial("tcp", server.Address().String())
+				Expect(connectError).NotTo(HaveOccurred())
+
+				nefariousHTTPMethod := strings.Repeat("POST", 2000)
+				writeString(conn, fmt.Sprintf("%s / HTTP/1.1\r\n\r\n", nefariousHTTPMethod))
+				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 501 Not Implemented\r\n"))
 			})
 		})
 

--- a/mock/http_mocks.go
+++ b/mock/http_mocks.go
@@ -13,7 +13,7 @@ type RequestParser struct {
 	parseRequestReceived    []byte
 }
 
-func (parser *RequestParser) ParseRequest(reader *bufio.Reader) (http.Request, *http.ParseError) {
+func (parser *RequestParser) ParseRequest(reader *bufio.Reader) (*http.Request, *http.ParseError) {
 	allButLF, _ := reader.ReadBytes(byte('\r'))
 	shouldBeLF, _ := reader.ReadByte()
 	parser.parseRequestReceived = appendByte(allButLF, shouldBeLF)

--- a/mock/http_mocks.go
+++ b/mock/http_mocks.go
@@ -4,7 +4,32 @@ import (
 	"fmt"
 	. "github.com/onsi/gomega"
 	"net"
+	"github.com/kkrull/gohttp/http"
+	"bufio"
 )
+
+type RequestParser struct {
+	ParseRequestReturnError *http.ParseError
+	parseRequestReceived    []byte
+}
+
+func (parser *RequestParser) ParseRequest(reader *bufio.Reader) (http.Request, *http.ParseError) {
+	allButLF, _ := reader.ReadBytes(byte('\r'))
+	shouldBeLF, _ := reader.ReadByte()
+	parser.parseRequestReceived = appendByte(allButLF, shouldBeLF)
+	return nil, parser.ParseRequestReturnError
+}
+
+func appendByte(allButLast []byte, last byte) []byte {
+	whole := make([]byte, len(allButLast)+1)
+	copy(whole, allButLast)
+	whole[len(whole)-1] = last
+	return whole
+}
+
+func (parser RequestParser) VerifyReceived(expected []byte) {
+	Expect(parser.parseRequestReceived).To(Equal(expected))
+}
 
 type Server struct {
 	StartFails  string

--- a/mock/http_mocks.go
+++ b/mock/http_mocks.go
@@ -9,15 +9,16 @@ import (
 )
 
 type RequestParser struct {
-	ParseRequestReturnError *http.ParseError
-	parseRequestReceived    []byte
+	ReturnsRequest *http.Request
+	ReturnsError   *http.ParseError
+	received       []byte
 }
 
 func (parser *RequestParser) ParseRequest(reader *bufio.Reader) (*http.Request, *http.ParseError) {
 	allButLF, _ := reader.ReadBytes(byte('\r'))
 	shouldBeLF, _ := reader.ReadByte()
-	parser.parseRequestReceived = appendByte(allButLF, shouldBeLF)
-	return nil, parser.ParseRequestReturnError
+	parser.received = appendByte(allButLF, shouldBeLF)
+	return parser.ReturnsRequest, parser.ReturnsError
 }
 
 func appendByte(allButLast []byte, last byte) []byte {
@@ -28,7 +29,7 @@ func appendByte(allButLast []byte, last byte) []byte {
 }
 
 func (parser RequestParser) VerifyReceived(expected []byte) {
-	Expect(parser.parseRequestReceived).To(Equal(expected))
+	Expect(parser.received).To(Equal(expected))
 }
 
 type Server struct {


### PR DESCRIPTION
This includes a lot of testing of smaller components to fill in the gaps on the walking skeleton.
It's also got just enough of `GET /` to pass `SimpleGet` in `cob_spec`.