### PR TITLE
Graceful shutdown of http.TCPServer on Ctrl+C

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -1,9 +1,5 @@
 # Developer backlog
 
-## Main
-
-- Handle Ctrl+C signal so it can exit with 0 instead of non-zero.
-
 
 ## Request parsing
 

--- a/http/request.go
+++ b/http/request.go
@@ -2,8 +2,8 @@ package http
 
 import (
 	"bufio"
-	"strings"
 	"fmt"
+	"strings"
 )
 
 type RequestParser interface {

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -1,12 +1,12 @@
 package http_test
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"github.com/kkrull/gohttp/http"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"fmt"
-	"bytes"
-	"bufio"
-	"github.com/kkrull/gohttp/http"
 )
 
 var _ = Describe("RFC7230RequestParser", func() {
@@ -89,7 +89,7 @@ var _ = Describe("RFC7230RequestParser", func() {
 			It("returns no error", func() {
 				Expect(err).To(BeNil())
 			})
-			
+
 			It("reads the entire request until reaching a line with only CRLF", func() {
 				Expect(reader.Buffered()).To(Equal(0))
 			})

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+
 	"github.com/kkrull/gohttp/http"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"

--- a/http/server.go
+++ b/http/server.go
@@ -1,9 +1,9 @@
 package http
 
 import (
+	"bufio"
 	"fmt"
 	"net"
-	"bufio"
 )
 
 func MakeTCPServerOnAvailablePort(contentRootDirectory string, host string) Server {

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -1,13 +1,13 @@
 package http_test
 
 import (
+	"bytes"
+	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/mock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/kkrull/gohttp/http"
-	"net"
-	"bytes"
-	"github.com/kkrull/gohttp/mock"
 	"io/ioutil"
+	"net"
 )
 
 var (

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -2,12 +2,14 @@ package http_test
 
 import (
 	"bytes"
-	"github.com/kkrull/gohttp/http"
-	"github.com/kkrull/gohttp/mock"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"net"
+
+	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/mock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/kkrull/gohttp/http"
 	"io"
 	"os"
 	"os/signal"
+
+	"github.com/kkrull/gohttp/http"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -32,17 +32,19 @@ func subscribeToSignals(sig os.Signal) <-chan os.Signal {
 
 func NewCliCommandParser(interrupts <-chan os.Signal) *CliCommandParser {
 	return &CliCommandParser{
-		Interrupts: interrupts,
-		NewCommandToRunHTTPServer: func(contentRootPath string, host string, port uint16) (CliCommand, chan bool) {
-			server := http.MakeTCPServer(contentRootPath, host, port)
-			return NewRunServerCommand(server)
-		},
+		Interrupts:                interrupts,
+		NewCommandToRunHTTPServer: NewCommandToRunHTTPServer,
 	}
 }
 
 type CliCommandParser struct {
 	Interrupts                <-chan os.Signal
 	NewCommandToRunHTTPServer MakeCommandToRunHTTPServer
+}
+
+func NewCommandToRunHTTPServer(contentRootPath string, host string, port uint16) (CliCommand, chan bool) {
+	server := http.MakeTCPServer(contentRootPath, host, port)
+	return NewRunServerCommand(server)
 }
 
 type MakeCommandToRunHTTPServer func(contentRootPath string, host string, port uint16) (

--- a/main.go
+++ b/main.go
@@ -81,13 +81,13 @@ func (command HelpCommand) Run(stderr io.Writer) (code int, err error) {
 
 func MakeRunServerCommand(server http.Server) (command CliCommand, quit chan bool) {
 	quit = make(chan bool, 1)
-	command = RunServerCommand{Server: server, Quit: quit}
+	command = RunServerCommand{Server: server, quit: quit}
 	return
 }
 
 type RunServerCommand struct {
 	Server http.Server
-	Quit   chan bool
+	quit   chan bool
 }
 
 func (command RunServerCommand) Run(stderr io.Writer) (code int, err error) {
@@ -104,5 +104,5 @@ func (command RunServerCommand) Run(stderr io.Writer) (code int, err error) {
 }
 
 func (command RunServerCommand) waitForShutdownRequest() {
-	<-command.Quit
+	<-command.quit
 }

--- a/main_test.go
+++ b/main_test.go
@@ -18,15 +18,21 @@ var _ = Describe("CliCommandParser", func() {
 	Describe("#Build", func() {
 		var (
 			parser  *CliCommandParser
+			interrupts chan os.Signal
+
 			command CliCommand
 			stderr  *bytes.Buffer
 		)
 
+		BeforeEach(func() {
+			interrupts = make(chan os.Signal, 1)
+			parser = NewCliCommandParser(interrupts)
+			stderr = &bytes.Buffer{}
+		})
+
 		Context("given --help", func() {
 			BeforeEach(func() {
-				parser = &CliCommandParser{}
 				command = parser.Parse([]string{"/path/to/gohttp", "--help"})
-				stderr = &bytes.Buffer{}
 			})
 
 			It("returns HelpCommand", func() {
@@ -44,18 +50,16 @@ var _ = Describe("CliCommandParser", func() {
 		})
 
 		Context("given a complete configuration for the HTTP server", func() {
-			It("returns RunServerCommand", func() {
+			It("returns a RunServerCommand", func() {
 				parser = &CliCommandParser{}
 				command = parser.Parse([]string{"gohttp", "-p", "4242", "-d", "/tmp"})
 				Expect(command).To(BeAssignableToTypeOf(RunServerCommand{}))
 			})
 
 			It("the command waits until a signal is sent to the interrupt signal channel", func(done Done) {
-				interrupts := make(chan os.Signal, 1)
 				parser = &CliCommandParser{Interrupts: interrupts}
 				command = parser.Parse([]string{"gohttp", "-p", "4242", "-d", "/tmp"})
 
-				//TODO KDK: See if MakeRunServerCommand can be stubbed to return my own channel, so I can test if sending an interrupt signal results in the quit channel receiving
 				go func() {
 					command.Run(stderr)
 					close(done)
@@ -67,7 +71,6 @@ var _ = Describe("CliCommandParser", func() {
 
 		Context("given unrecognized arguments", func() {
 			It("returns ErrorCommand", func() {
-				parser = &CliCommandParser{}
 				command = parser.Parse([]string{"gohttp", "--bogus"})
 				Expect(command).To(BeAssignableToTypeOf(ErrorCommand{}))
 			})
@@ -75,7 +78,6 @@ var _ = Describe("CliCommandParser", func() {
 
 		Context("when the path is missing", func() {
 			It("returns ErrorCommand", func() {
-				parser = &CliCommandParser{}
 				command = parser.Parse([]string{"gohttp", "-p", "4242"})
 				Expect(command).To(BeAssignableToTypeOf(ErrorCommand{}))
 			})
@@ -83,7 +85,6 @@ var _ = Describe("CliCommandParser", func() {
 
 		Context("when the port is missing", func() {
 			It("returns ErrorCommand", func() {
-				parser = &CliCommandParser{}
 				command = parser.Parse([]string{"gohttp", "-d", "/tmp"})
 				Expect(command).To(BeAssignableToTypeOf(ErrorCommand{}))
 			})
@@ -142,7 +143,7 @@ var _ = Describe("CliCommands", func() {
 			Context("given a workable configuration", func() {
 				BeforeEach(func() {
 					server = mock.Server{}
-					command, quit = MakeRunServerCommand(&server)
+					command, quit = NewRunServerCommand(&server)
 				})
 
 				It("runs the server until the quit channel receives something", func(done Done) {
@@ -162,7 +163,7 @@ var _ = Describe("CliCommands", func() {
 			Context("when everything has run ok", func() {
 				BeforeEach(func() {
 					server = mock.Server{}
-					command, quit = MakeRunServerCommand(&server)
+					command, quit = NewRunServerCommand(&server)
 				})
 
 				It("returns 0 and no error", func() {
@@ -176,7 +177,7 @@ var _ = Describe("CliCommands", func() {
 			Context("when there is an error starting the server", func() {
 				It("returns the error and an exit code indicating failure", func() {
 					server = mock.Server{StartFails: "no listening ears"}
-					command, quit = MakeRunServerCommand(&server)
+					command, quit = NewRunServerCommand(&server)
 					code, err = command.Run(stderr)
 					Expect(code).To(Equal(2))
 					Expect(err).To(MatchError("no listening ears"))
@@ -186,7 +187,7 @@ var _ = Describe("CliCommands", func() {
 			Context("when there is an error shutting down", func() {
 				It("returns the error and an exit code indicating failure", func() {
 					server = mock.Server{ShutdownFails: "backfire"}
-					command, quit = MakeRunServerCommand(&server)
+					command, quit = NewRunServerCommand(&server)
 					go scheduleShutdown(quit)
 					code, err = command.Run(stderr)
 					Expect(code).To(Equal(3))

--- a/main_test.go
+++ b/main_test.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	. "github.com/kkrull/gohttp"
 	"github.com/kkrull/gohttp/mock"
-	"time"
 	"os"
 	"syscall"
+	"time"
 )
 
 var _ = Describe("CliCommandParser", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -56,7 +56,7 @@ var _ = Describe("CliCommandParser", func() {
 				Expect(command).To(BeAssignableToTypeOf(RunServerCommand{}))
 			})
 
-			It("the command waits until a signal is sent to the interrupt signal channel", func(done Done) {
+			It("the command waits until a signal is sent to the interrupt signal channel", func() {
 				quitHttpServer := make(chan bool, 1)
 				parser = &CliCommandParser{
 					Interrupts: interrupts,
@@ -65,11 +65,8 @@ var _ = Describe("CliCommandParser", func() {
 					}}
 
 				command = parser.Parse([]string{"gohttp", "-p", "4242", "-d", "/tmp"})
-				go func() {
-					<-quitHttpServer
-					close(done)
-				}()
 				interrupts <- syscall.SIGINT
+				Eventually(quitHttpServer).Should(Receive())
 			})
 		})
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,17 +1,18 @@
 package main_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"bytes"
 	"flag"
 	"fmt"
-	. "github.com/kkrull/gohttp"
-	"github.com/kkrull/gohttp/mock"
 	"os"
 	"syscall"
 	"time"
+
+	. "github.com/kkrull/gohttp"
+	"github.com/kkrull/gohttp/mock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("CliCommandParser", func() {

--- a/mock/http_mocks.go
+++ b/mock/http_mocks.go
@@ -1,11 +1,11 @@
 package mock
 
 import (
+	"bufio"
 	"fmt"
+	"github.com/kkrull/gohttp/http"
 	. "github.com/onsi/gomega"
 	"net"
-	"github.com/kkrull/gohttp/http"
-	"bufio"
 )
 
 type RequestParser struct {


### PR DESCRIPTION
I noticed earlier that `gohttp` would shut down with a non-zero exit code when I pressed `Ctrl+C` to terminate the process, and I thought that could be better.

So I registered for notifications of `SIGINT` and use that to trigger `http.Server#Shutdown`.
I'm not sure I'm thrilled with the stub returns a stub approach that I used to test this, but I thought I'd try it out once to see how it works out.  I put some thoughts on the pros/cons of this in one of the commit messages, if you're curious.