### PR TITLE
Basic handling of GET requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 gohttp
 *.pcap
 
+.test/

--- a/backlog.md
+++ b/backlog.md
@@ -11,6 +11,10 @@
   * Given HTTP/1.2+ -- should it respond with 501 Not Implemented?
     RFC 7231 seems to suggest that it's only meant for an unsupported _method_.
   * Given HTTP/2+ -- it could respond 505 HTTP Version Not Supported
+* Hard-coded responses can be turned into XyzResponse types
+  * 400 Bad Request
+  * 500 Internal Server Error
+
 
 ## Request parsing
 

--- a/backlog.md
+++ b/backlog.md
@@ -6,7 +6,11 @@
 * Missing ways to cause I/O errors with
   * `io.Writer`
   * `net.TCPConn`
-
+* HTTP version
+  * Given HTTP/1.0 -- it could respond 426 Upgrade Required with Upgrade: HTTP/1.1 and Connection: Upgrade
+  * Given HTTP/1.2+ -- should it respond with 501 Not Implemented?
+    RFC 7231 seems to suggest that it's only meant for an unsupported _method_.
+  * Given HTTP/2+ -- it could respond 505 HTTP Version Not Supported
 
 ## Request parsing
 

--- a/backlog.md
+++ b/backlog.md
@@ -15,3 +15,11 @@ RFC7230 Section 3.1.1
 * Should allow a request line of at least 8,000 octets.  On the flip side, prevent a
   Denial of Service attack with a request line that (almost) never ends (has no CR).
   In this case, it should only read up to 8,000 octets and give up if it hasn't seen CR yet.
+
+
+## General
+
+- Are interface types declared on the client/callee side?
+- When they are in the right package, do they need to be exported anymore?
+- Is the current request handling, parsing, and error handling getting large enough to benefit from being in a separate
+  `handler/filesystem` package?

--- a/backlog.md
+++ b/backlog.md
@@ -19,7 +19,5 @@ RFC7230 Section 3.1.1
 
 ## General
 
-- Are interface types declared on the client/callee side?
-- When they are in the right package, do they need to be exported anymore?
-- Is the current request handling, parsing, and error handling getting large enough to benefit from being in a separate
+* Is the current request handling, parsing, and error handling getting large enough to benefit from being in a separate
   `handler/filesystem` package?

--- a/backlog.md
+++ b/backlog.md
@@ -5,6 +5,7 @@
 * Missing ways to cause I/O errors with
   * `io.Writer`
   * `net.TCPConn`
+  * `os.File`
 * Hard-coded responses can be turned into XyzResponse types
   * 400 Bad Request
   * 500 Internal Server Error

--- a/backlog.md
+++ b/backlog.md
@@ -2,15 +2,9 @@
 
 ## Handling requests
 
-* If there is an error handling a request, it should respond 500 Internal Server Error, if at all possible.
 * Missing ways to cause I/O errors with
   * `io.Writer`
   * `net.TCPConn`
-* HTTP version
-  * Given HTTP/1.0 -- it could respond 426 Upgrade Required with Upgrade: HTTP/1.1 and Connection: Upgrade
-  * Given HTTP/1.2+ -- should it respond with 501 Not Implemented?
-    RFC 7231 seems to suggest that it's only meant for an unsupported _method_.
-  * Given HTTP/2+ -- it could respond 505 HTTP Version Not Supported
 * Hard-coded responses can be turned into XyzResponse types
   * 400 Bad Request
   * 500 Internal Server Error
@@ -18,14 +12,26 @@
 
 ## Request parsing
 
-RFC7230 Section 3.1.1
-
-* Should allow a request line of at least 8,000 octets.  On the flip side, prevent a
+* Denial of Service: Should allow a request line of at least 8,000 octets.  On the flip side, prevent a
   Denial of Service attack with a request line that (almost) never ends (has no CR).
   In this case, it should only read up to 8,000 octets and give up if it hasn't seen CR yet.
+  See RFC 7230 Section 3.1.1 for details
+* HTTP version
+  * Given HTTP/1.0 -- it could respond 426 Upgrade Required with Upgrade: HTTP/1.1 and Connection: Upgrade
+  * Given HTTP/1.2+ -- should it respond with 501 Not Implemented?
+    RFC 7231 seems to suggest that it's only meant for an unsupported _method_.
+  * Given HTTP/2+ -- it could respond 505 HTTP Version Not Supported
 
 
-## General
+## Packaging
 
 * Is the current request handling, parsing, and error handling getting large enough to benefit from being in a separate
   `handler/filesystem` package?
+
+
+## Tests
+
+* Some types have been extracted after tests have been written on an outer layer.  If there is going to be a lot more
+  development on these tests, it may make sense to refactor some of these tests to
+  * test the delegation to the recently-extracted type
+  * move / refactor the existing tests that apply to the recently-extracted type, down to that level

--- a/backlog.md
+++ b/backlog.md
@@ -1,12 +1,17 @@
 # Developer backlog
 
+## Handling requests
+
+* If there is an error handling a request, it should respond 500 Internal Server Error, if at all possible.
+* Missing ways to cause I/O errors with
+  * `io.Writer`
+  * `net.TCPConn`
+
 
 ## Request parsing
 
 RFC7230 Section 3.1.1
 
-- Should allow a request line of at least 8,000 octets.  On the flip side, prevent a
+* Should allow a request line of at least 8,000 octets.  On the flip side, prevent a
   Denial of Service attack with a request line that (almost) never ends (has no CR).
   In this case, it should only read up to 8,000 octets and give up if it hasn't seen CR yet.
-- I/O errors when reading from the socket.
-  Need to invest in a mock bufio.Reader that returns errors.

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -25,4 +25,3 @@ func (request *GetRequest) Handle(conn *bufio.Writer) error {
 		return nil
 	}
 }
-

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -22,7 +22,7 @@ func (request *GetRequest) Handle(client *bufio.Writer) error {
 	info, err := os.Stat(resolvedTarget)
 	if err != nil {
 		response := &NotFoundResponse{client: client}
-		response.Issue(request.Target)
+		response.IssueForTarget(request.Target)
 	} else if info.IsDir() {
 		writeStatusLine(client, 200, "OK")
 		writeHeader(client, "Content-Type", "text/plain")
@@ -41,7 +41,7 @@ func (request *GetRequest) Handle(client *bufio.Writer) error {
 		writeBody(client, message.String())
 	} else {
 		response := &FileContentsResponse{client: client}
-		response.Issue(resolvedTarget)
+		response.IssueForFile(resolvedTarget)
 	}
 
 	client.Flush()
@@ -53,7 +53,7 @@ type FileContentsResponse struct {
 	client *bufio.Writer
 }
 
-func (response FileContentsResponse) Issue(filename string) {
+func (response FileContentsResponse) IssueForFile(filename string) {
 	writeStatusLine(response.client, 200, "OK")
 	writeHeader(response.client, "Content-Type", "text/plain")
 
@@ -70,7 +70,7 @@ type NotFoundResponse struct {
 	client *bufio.Writer
 }
 
-func (response NotFoundResponse) Issue(requestTarget string) {
+func (response NotFoundResponse) IssueForTarget(requestTarget string) {
 	writeStatusLine(response.client, 404, "Not Found")
 	writeHeader(response.client, "Content-Type", "text/plain")
 

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -14,7 +14,6 @@ import (
 type GetRequest struct {
 	BaseDirectory string
 	Target        string
-	Version       string //TODO KDK: Not used
 }
 
 func (request *GetRequest) Handle(client *bufio.Writer) error {

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -20,6 +20,8 @@ func (request *GetRequest) Handle(client *bufio.Writer) error {
 	info, err := os.Stat(resolvedTarget)
 	if err != nil {
 		writeStatusLine(client, 404, "Not Found")
+		writeHeader(client, "Content-Length", strconv.FormatInt(0, 10))
+		writeEndOfHeader(client)
 	} else {
 		writeStatusLine(client, 200, "OK")
 		writeHeader(client, "Content-Length", strconv.FormatInt(info.Size(), 10))

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -22,6 +22,7 @@ func (request *GetRequest) Handle(conn *bufio.Writer) error {
 		return nil
 	default:
 		fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")
+		conn.Flush()
 		return nil
 	}
 }

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -1,0 +1,28 @@
+package http
+
+import (
+	"bufio"
+	"fmt"
+)
+
+type GetRequest struct {
+	Method  string
+	Target  string
+	Version string
+}
+
+func (request *GetRequest) Handle(conn *bufio.Writer) error {
+	switch request.Target {
+	case "/":
+		fmt.Fprint(conn, "HTTP/1.1 200 OK\r\n")
+		fmt.Fprint(conn, "Content-Length: 5\r\n")
+		fmt.Fprint(conn, "Content-Type: text/plain\r\n")
+		fmt.Fprint(conn, "\r\n")
+		fmt.Fprintf(conn, "hello")
+		return nil
+	default:
+		fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")
+		return nil
+	}
+}
+

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -16,13 +16,22 @@ type GetRequest struct {
 }
 
 func (request *GetRequest) Handle(client *bufio.Writer) error {
-	resolvedTarget := path.Join(request.BaseDirectory, request.Target)
+	resolvedTarget := path.Join(request.BaseDirectory, request.Target) //TODO KDK: ioutil.ReadDir
 	info, err := os.Stat(resolvedTarget)
 	if err != nil {
 		writeStatusLine(client, 404, "Not Found")
 		writeHeader(client, "Content-Type", "text/plain")
 
 		message := fmt.Sprintf("Not found: %s", request.Target)
+		writeHeader(client, "Content-Length", strconv.Itoa(len(message)))
+		writeEndOfHeader(client)
+
+		writeBody(client, message)
+	} else if info.IsDir() {
+		writeStatusLine(client, 200, "OK")
+		writeHeader(client, "Content-Type", "text/plain")
+
+		message := fmt.Sprintf("one\n")
 		writeHeader(client, "Content-Length", strconv.Itoa(len(message)))
 		writeEndOfHeader(client)
 
@@ -50,7 +59,7 @@ func writeHeader(client *bufio.Writer, name string, value string) {
 }
 
 func writeEndOfHeader(client *bufio.Writer) {
-	fmt.Fprintf(client, "\r\n")
+	fmt.Fprint(client, "\r\n")
 }
 
 func copyToBody(client *bufio.Writer, bodyReader io.Reader) {
@@ -58,5 +67,5 @@ func copyToBody(client *bufio.Writer, bodyReader io.Reader) {
 }
 
 func writeBody(client *bufio.Writer, body string) {
-	fmt.Fprintf(client, body)
+	fmt.Fprint(client, body)
 }

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -20,8 +20,12 @@ func (request *GetRequest) Handle(client *bufio.Writer) error {
 	info, err := os.Stat(resolvedTarget)
 	if err != nil {
 		writeStatusLine(client, 404, "Not Found")
-		writeHeader(client, "Content-Length", strconv.FormatInt(0, 10))
+
+		message := fmt.Sprintf("Not found: %s", request.Target)
+		writeHeader(client, "Content-Length", strconv.Itoa(len(message)))
+		writeHeader(client, "Content-Type", "text/plain")
 		writeEndOfHeader(client)
+		fmt.Fprintf(client, message)
 	} else {
 		writeStatusLine(client, 200, "OK")
 		writeHeader(client, "Content-Length", strconv.FormatInt(info.Size(), 10))

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -6,9 +6,9 @@ import (
 )
 
 type GetRequest struct {
-	Method  string
-	Target  string
-	Version string
+	BaseDirectory string
+	Target        string
+	Version       string
 }
 
 func (request *GetRequest) Handle(conn *bufio.Writer) error {

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -20,28 +20,25 @@ func (request *GetRequest) Handle(client *bufio.Writer) error {
 	info, err := os.Stat(resolvedTarget)
 	if err != nil {
 		writeStatusLine(client, 404, "Not Found")
+		writeHeader(client, "Content-Type", "text/plain")
 
 		message := fmt.Sprintf("Not found: %s", request.Target)
 		writeHeader(client, "Content-Length", strconv.Itoa(len(message)))
-		writeHeader(client, "Content-Type", "text/plain")
 		writeEndOfHeader(client)
-		fmt.Fprintf(client, message)
+
+		writeBody(client, message)
 	} else {
 		writeStatusLine(client, 200, "OK")
-		writeHeader(client, "Content-Length", strconv.FormatInt(info.Size(), 10))
 		writeHeader(client, "Content-Type", "text/plain")
+		writeHeader(client, "Content-Length", strconv.FormatInt(info.Size(), 10))
 		writeEndOfHeader(client)
 
 		file, _ := os.Open(resolvedTarget)
-		writeBody(client, file)
+		copyToBody(client, file)
 	}
 
 	client.Flush()
 	return nil
-}
-
-func writeBody(client *bufio.Writer, body io.Reader) {
-	io.Copy(client, body)
 }
 
 func writeStatusLine(client *bufio.Writer, status int, reason string) {
@@ -54,4 +51,12 @@ func writeHeader(client *bufio.Writer, name string, value string) {
 
 func writeEndOfHeader(client *bufio.Writer) {
 	fmt.Fprintf(client, "\r\n")
+}
+
+func copyToBody(client *bufio.Writer, bodyReader io.Reader) {
+	io.Copy(client, bodyReader)
+}
+
+func writeBody(client *bufio.Writer, body string) {
+	fmt.Fprintf(client, body)
 }

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -35,7 +35,6 @@ func (request *GetRequest) Handle(client *bufio.Writer) error {
 	return nil
 }
 
-
 type DirectoryListingResponse struct {
 	client *bufio.Writer
 }
@@ -62,7 +61,6 @@ func messageListingFiles(files []os.FileInfo) *bytes.Buffer {
 	return message
 }
 
-
 type TextFileContentsResponse struct {
 	client *bufio.Writer
 }
@@ -82,7 +80,6 @@ func writeHeadersDescribingFile(response TextFileContentsResponse, filename stri
 	writeHeader(response.client, "Content-Length", strconv.FormatInt(info.Size(), 10))
 }
 
-
 type NotFoundResponse struct {
 	client *bufio.Writer
 }
@@ -97,7 +94,6 @@ func (response NotFoundResponse) IssueForTarget(requestTarget string) {
 
 	writeBody(response.client, message)
 }
-
 
 func writeStatusLine(client *bufio.Writer, status int, reason string) {
 	fmt.Fprintf(client, "HTTP/1.1 %d %s\r\n", status, reason)

--- a/http/get_request.go
+++ b/http/get_request.go
@@ -11,18 +11,18 @@ type GetRequest struct {
 	Version       string
 }
 
-func (request *GetRequest) Handle(conn *bufio.Writer) error {
+func (request *GetRequest) Handle(response *bufio.Writer) error {
 	switch request.Target {
 	case "/":
-		fmt.Fprint(conn, "HTTP/1.1 200 OK\r\n")
-		fmt.Fprint(conn, "Content-Length: 5\r\n")
-		fmt.Fprint(conn, "Content-Type: text/plain\r\n")
-		fmt.Fprint(conn, "\r\n")
-		fmt.Fprintf(conn, "hello")
-		return nil
+		fmt.Fprint(response, "HTTP/1.1 200 OK\r\n")
+		fmt.Fprint(response, "Content-Length: 5\r\n")
+		fmt.Fprint(response, "Content-Type: text/plain\r\n")
+		fmt.Fprint(response, "\r\n")
+		fmt.Fprintf(response, "hello")
 	default:
-		fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")
-		conn.Flush()
-		return nil
+		fmt.Fprint(response, "HTTP/1.1 404 Not Found\r\n")
 	}
+
+	response.Flush()
+	return nil
 }

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -1,6 +1,8 @@
 package http_test
 
 import (
+	"bufio"
+	"bytes"
 	"os"
 	"path"
 
@@ -19,12 +21,17 @@ var _ = Describe("GetRequest", func() {
 			basePath = makeEmptyTestDirectory("GetRequest", os.ModePerm)
 		})
 
-		It("accepts a base path", func() {
-			request := http.GetRequest{
-				BaseDirectory: "/tmp",
-				Target:        "/",
-				Version:       "HTTP/1.1"}
-			Expect(request).NotTo(BeNil())
+		Context("when the resolved target does not exist", func() {
+			It("Responds with 404 Not Found", func() {
+				buffer := &bytes.Buffer{}
+				writer := bufio.NewWriter(buffer)
+				request := http.GetRequest{
+					BaseDirectory: basePath,
+					Target:        "/missing.txt",
+					Version:       "HTTP/1.1"}
+				Expect(request.Handle(writer)).To(Succeed())
+				Expect(buffer.String()).To(Equal("HTTP/1.1 404 Not Found\r\n"))
+			})
 		})
 	})
 })

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -3,6 +3,7 @@ package http_test
 import (
 	"bufio"
 	"bytes"
+	"io/ioutil"
 	"os"
 	"path"
 
@@ -39,6 +40,28 @@ var _ = Describe("GetRequest", func() {
 			})
 			It("Responds with 404 Not Found", func() {
 				Expect(response.String()).To(Equal("HTTP/1.1 404 Not Found\r\n"))
+			})
+		})
+
+		Context("when the target is a readable file in the specified path", func() {
+			BeforeEach(func() {
+				request = &http.GetRequest{
+					BaseDirectory: basePath,
+					Target:        "/readable.txt",
+					Version:       "HTTP/1.1"}
+
+				Expect(ioutil.WriteFile(
+					path.Join(basePath, "readable.txt"),
+					[]byte{42},
+					os.ModePerm)).To(Succeed())
+				err = request.Handle(bufio.NewWriter(response))
+			})
+
+			It("returns no error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("Responds with 200 OK", func() {
+				Expect(response.String()).To(Equal("HTTP/1.1 200 OK\r\n"))
 			})
 		})
 	})

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -1,7 +1,6 @@
 package http_test
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"os"
@@ -32,7 +31,7 @@ var _ = Describe("GetRequest", func() {
 				request = &http.GetRequest{
 					BaseDirectory: basePath,
 					Target:        "/missing.txt"}
-				err = request.Handle(bufio.NewWriter(response))
+				err = request.Handle(response)
 			})
 
 			It("returns no error", func() {
@@ -60,7 +59,7 @@ var _ = Describe("GetRequest", func() {
 
 				existingFile := path.Join(basePath, "readable.txt")
 				Expect(createTextFile(existingFile, "A")).To(Succeed())
-				err = request.Handle(bufio.NewWriter(response))
+				err = request.Handle(response)
 			})
 
 			It("returns no error", func() {
@@ -88,7 +87,7 @@ var _ = Describe("GetRequest", func() {
 
 				existingFile := path.Join(basePath, "one")
 				Expect(createTextFile(existingFile, "1")).To(Succeed())
-				err = request.Handle(bufio.NewWriter(response))
+				err = request.Handle(response)
 			})
 
 			It("returns no error", func() {

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -41,6 +41,8 @@ var _ = Describe("GetRequest", func() {
 			It("Responds with 404 Not Found", func() {
 				Expect(response.String()).To(Equal("HTTP/1.1 404 Not Found\r\n"))
 			})
+			XIt("ends the header section")
+			XIt("writes a content length of 0?")
 		})
 
 		Context("when the target is a readable file in the specified path", func() {

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -14,23 +14,31 @@ import (
 var _ = Describe("GetRequest", func() {
 	Describe("#Handle", func() {
 		var (
+			request  *http.GetRequest
 			basePath string
+			response *bytes.Buffer
+			err      error
 		)
 
 		BeforeEach(func() {
 			basePath = makeEmptyTestDirectory("GetRequest", os.ModePerm)
+			response = &bytes.Buffer{}
 		})
 
 		Context("when the resolved target does not exist", func() {
-			It("Responds with 404 Not Found", func() {
-				buffer := &bytes.Buffer{}
-				writer := bufio.NewWriter(buffer)
-				request := http.GetRequest{
+			BeforeEach(func() {
+				request = &http.GetRequest{
 					BaseDirectory: basePath,
 					Target:        "/missing.txt",
 					Version:       "HTTP/1.1"}
-				Expect(request.Handle(writer)).To(Succeed())
-				Expect(buffer.String()).To(Equal("HTTP/1.1 404 Not Found\r\n"))
+				err = request.Handle(bufio.NewWriter(response))
+			})
+
+			It("returns no error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("Responds with 404 Not Found", func() {
+				Expect(response.String()).To(Equal("HTTP/1.1 404 Not Found\r\n"))
 			})
 		})
 	})

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GetRequest", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("Responds with 404 Not Found", func() {
-				Expect(response.String()).To(startWithStatusLine(404, "Not Found"))
+				Expect(response.String()).To(haveStatus(404, "Not Found"))
 			})
 			It("sets Content-Length to the length of the response", func() {
 				Expect(response.String()).To(containHeader("Content-Length", "23"))
@@ -49,7 +49,7 @@ var _ = Describe("GetRequest", func() {
 				Expect(response.String()).To(containHeader("Content-Type", "text/plain"))
 			})
 			It("writes an error message to the message body", func() {
-				Expect(response.String()).To(HaveSuffix("\r\nNot found: /missing.txt"))
+				Expect(response.String()).To(haveMessageBody("Not found: /missing.txt"))
 			})
 		})
 
@@ -69,7 +69,7 @@ var _ = Describe("GetRequest", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("responds with 200 OK", func() {
-				Expect(response.String()).To(startWithStatusLine(200, "OK"))
+				Expect(response.String()).To(haveStatus(200, "OK"))
 			})
 			It("sets Content-Length to the number of bytes in the file", func() {
 				Expect(response.String()).To(containHeader("Content-Length", "1"))
@@ -78,7 +78,7 @@ var _ = Describe("GetRequest", func() {
 				Expect(response.String()).To(containHeader("Content-Type", "text/plain"))
 			})
 			It("writes the contents of the file to the message body", func() {
-				Expect(response.String()).To(HaveSuffix("\r\n\r\nA"))
+				Expect(response.String()).To(haveMessageBody("A"))
 			})
 		})
 	})
@@ -108,10 +108,14 @@ func createTextFile(filename string, contents string) error {
 	return nil
 }
 
-func startWithStatusLine(status int, reason string) types.GomegaMatcher {
+func haveStatus(status int, reason string) types.GomegaMatcher {
 	return HavePrefix(fmt.Sprintf("HTTP/1.1 %d %s\r\n", status, reason))
 }
 
 func containHeader(name string, value string) types.GomegaMatcher {
 	return ContainSubstring(fmt.Sprintf("%s: %s\r\n", name, value))
+}
+
+func haveMessageBody(message string) types.GomegaMatcher {
+	return HaveSuffix(fmt.Sprintf("\r\n\r\n%s", message))
 }

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -1,18 +1,37 @@
 package http_test
 
 import (
-	"github.com/kkrull/gohttp/http"
+	"os"
+	"path"
 
+	"github.com/kkrull/gohttp/http"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("GetRequest", func() {
-	It("accepts a base path", func() {
-		request := http.GetRequest{
-			BaseDirectory: "/tmp",
-			Target:  "/",
-			Version: "HTTP/1.1"}
-		Expect(request).NotTo(BeNil())
+	Describe("#Handle", func() {
+		var (
+			basePath string
+		)
+
+		BeforeEach(func() {
+			basePath = makeEmptyTestDirectory("GetRequest", os.ModePerm)
+		})
+
+		It("accepts a base path", func() {
+			request := http.GetRequest{
+				BaseDirectory: "/tmp",
+				Target:        "/",
+				Version:       "HTTP/1.1"}
+			Expect(request).NotTo(BeNil())
+		})
 	})
 })
+
+func makeEmptyTestDirectory(testName string, fileMode os.FileMode) string {
+	testPath := path.Join(".test", testName)
+	Expect(os.RemoveAll(testPath)).To(Succeed())
+	Expect(os.MkdirAll(testPath, fileMode)).To(Succeed())
+	return testPath
+}

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -31,8 +31,7 @@ var _ = Describe("GetRequest", func() {
 			BeforeEach(func() {
 				request = &http.GetRequest{
 					BaseDirectory: basePath,
-					Target:        "/missing.txt",
-					Version:       "HTTP/1.1"}
+					Target:        "/missing.txt"}
 				err = request.Handle(bufio.NewWriter(response))
 			})
 
@@ -57,8 +56,7 @@ var _ = Describe("GetRequest", func() {
 			BeforeEach(func() {
 				request = &http.GetRequest{
 					BaseDirectory: basePath,
-					Target:        "/readable.txt",
-					Version:       "HTTP/1.1"}
+					Target:        "/readable.txt"}
 
 				existingFile := path.Join(basePath, "readable.txt")
 				Expect(createTextFile(existingFile, "A")).To(Succeed())
@@ -86,8 +84,7 @@ var _ = Describe("GetRequest", func() {
 			BeforeEach(func() {
 				request = &http.GetRequest{
 					BaseDirectory: basePath,
-					Target:        "/",
-					Version:       "HTTP/1.1"}
+					Target:        "/"}
 
 				existingFile := path.Join(basePath, "one")
 				Expect(createTextFile(existingFile, "1")).To(Succeed())

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -1,0 +1,18 @@
+package http_test
+
+import (
+	"github.com/kkrull/gohttp/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetRequest", func() {
+	It("accepts a base path", func() {
+		request := http.GetRequest{
+			BaseDirectory: "/tmp",
+			Target:  "/",
+			Version: "HTTP/1.1"}
+		Expect(request).NotTo(BeNil())
+	})
+})

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -53,7 +53,7 @@ var _ = Describe("GetRequest", func() {
 			})
 		})
 
-		Context("when the target is a readable file in the specified path", func() {
+		Context("when the target is a readable file in the base path", func() {
 			BeforeEach(func() {
 				request = &http.GetRequest{
 					BaseDirectory: basePath,
@@ -79,6 +79,35 @@ var _ = Describe("GetRequest", func() {
 			})
 			It("writes the contents of the file to the message body", func() {
 				Expect(response.String()).To(haveMessageBody("A"))
+			})
+		})
+
+		Context("when the target is /", func() {
+			BeforeEach(func() {
+				request = &http.GetRequest{
+					BaseDirectory: basePath,
+					Target:        "/",
+					Version:       "HTTP/1.1"}
+
+				existingFile := path.Join(basePath, "one")
+				Expect(createTextFile(existingFile, "1")).To(Succeed())
+				err = request.Handle(bufio.NewWriter(response))
+			})
+
+			It("returns no error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("responds with 200 OK", func() {
+				Expect(response.String()).To(haveStatus(200, "OK"))
+			})
+			It("sets Content-Length to the size of the message", func() {
+				Expect(response.String()).To(containHeader("Content-Length", "4"))
+			})
+			It("sets Content-Type to text/plain", func() {
+				Expect(response.String()).To(containHeader("Content-Type", "text/plain"))
+			})
+			It("lists the files in the base path", func() {
+				Expect(response.String()).To(haveMessageBody("one\n"))
 			})
 		})
 	})

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -39,10 +39,14 @@ var _ = Describe("GetRequest", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("Responds with 404 Not Found", func() {
-				Expect(response.String()).To(Equal("HTTP/1.1 404 Not Found\r\n"))
+				Expect(response.String()).To(HavePrefix("HTTP/1.1 404 Not Found\r\n"))
 			})
-			XIt("ends the header section")
-			XIt("writes a content length of 0?")
+			It("sets Content-Length to 0", func() {
+				Expect(response.String()).To(ContainSubstring("Content-Length: 0\r\n"))
+			})
+			It("has no body", func() {
+				Expect(response.String()).To(HaveSuffix("\r\n\r\n"))
+			})
 		})
 
 		Context("when the target is a readable file in the specified path", func() {

--- a/http/get_request_test.go
+++ b/http/get_request_test.go
@@ -42,11 +42,14 @@ var _ = Describe("GetRequest", func() {
 			It("Responds with 404 Not Found", func() {
 				Expect(response.String()).To(startWithStatusLine(404, "Not Found"))
 			})
-			It("sets Content-Length to 0", func() {
-				Expect(response.String()).To(containHeader("Content-Length", "0"))
+			It("sets Content-Length to the length of the response", func() {
+				Expect(response.String()).To(containHeader("Content-Length", "23"))
 			})
-			It("has no body", func() {
-				Expect(response.String()).To(HaveSuffix("\r\n\r\n"))
+			It("sets Content-Type to text/plain", func() {
+				Expect(response.String()).To(containHeader("Content-Type", "text/plain"))
+			})
+			It("writes an error message to the message body", func() {
+				Expect(response.String()).To(HaveSuffix("\r\nNot found: /missing.txt"))
 			})
 		})
 

--- a/http/request.go
+++ b/http/request.go
@@ -5,10 +5,6 @@ import (
 	"strings"
 )
 
-type RequestParser interface {
-	ParseRequest(reader *bufio.Reader) (Request, *ParseError)
-}
-
 type RFC7230RequestParser struct{}
 
 func (parser RFC7230RequestParser) ParseRequest(reader *bufio.Reader) (Request, *ParseError) {
@@ -71,10 +67,6 @@ func readCRLFLine(reader *bufio.Reader) (string, error) {
 
 	trimmed := strings.TrimSuffix(maybeEndsInCR, "\r")
 	return trimmed, nil
-}
-
-type Request interface {
-	Handle(connWriter *bufio.Writer) error
 }
 
 type MissingEndOfHeaderCRLF struct{}

--- a/http/request.go
+++ b/http/request.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 )
 
-type RFC7230RequestParser struct{}
+type RFC7230RequestParser struct {
+	BaseDirectory string
+}
 
 func (parser RFC7230RequestParser) ParseRequest(reader *bufio.Reader) (Request, *ParseError) {
-	request, err := parseRequestLine(reader)
+	request, err := parser.parseRequestLine(reader)
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +23,7 @@ func (parser RFC7230RequestParser) ParseRequest(reader *bufio.Reader) (Request, 
 	return request, nil
 }
 
-func parseRequestLine(reader *bufio.Reader) (*GetRequest, *ParseError) {
+func (parser RFC7230RequestParser) parseRequestLine(reader *bufio.Reader) (*GetRequest, *ParseError) {
 	requestLine, err := readCRLFLine(reader)
 	if err != nil {
 		return nil, &ParseError{StatusCode: 400, Reason: "Bad Request"}
@@ -32,11 +34,12 @@ func parseRequestLine(reader *bufio.Reader) (*GetRequest, *ParseError) {
 		return nil, &ParseError{StatusCode: 400, Reason: "Bad Request"}
 	}
 
-	switch fields[0] { //TODO KDK: Set the base path
+	switch fields[0] {
 	case "GET":
 		return &GetRequest{
-			Target:  fields[1],
-			Version: fields[2],
+			BaseDirectory: parser.BaseDirectory,
+			Target:        fields[1],
+			Version:       fields[2],
 		}, nil
 	default:
 		return nil, &ParseError{StatusCode: 501, Reason: "Not Implemented"}

--- a/http/request.go
+++ b/http/request.go
@@ -32,6 +32,7 @@ func parseRequestLine(reader *bufio.Reader) (*GetRequest, *ParseError) {
 		return nil, &ParseError{StatusCode: 400, Reason: "Bad Request"}
 	}
 
+	//TODO KDK: Create the appropriate kind of request based upon the verb.  Respond something like 405 Method Not Allowed or 501 Not Implemented
 	return &GetRequest{
 		Method:  fields[0],
 		Target:  fields[1],

--- a/http/request.go
+++ b/http/request.go
@@ -32,12 +32,17 @@ func parseRequestLine(reader *bufio.Reader) (*GetRequest, *ParseError) {
 		return nil, &ParseError{StatusCode: 400, Reason: "Bad Request"}
 	}
 
-	//TODO KDK: Create the appropriate kind of request based upon the verb.  Respond something like 405 Method Not Allowed or 501 Not Implemented
-	return &GetRequest{
-		Method:  fields[0],
-		Target:  fields[1],
-		Version: fields[2],
-	}, nil
+	method := fields[0]
+	switch method {
+	case "GET":
+		return &GetRequest{
+			Method:  method,
+			Target:  fields[1],
+			Version: fields[2],
+		}, nil
+	default:
+		return nil, &ParseError{StatusCode: 501, Reason: "Not Implemented"}
+	}
 }
 
 func parseHeaderLines(reader *bufio.Reader) *ParseError {

--- a/http/request.go
+++ b/http/request.go
@@ -39,7 +39,6 @@ func (parser RFC7230RequestParser) parseRequestLine(reader *bufio.Reader) (*GetR
 		return &GetRequest{
 			BaseDirectory: parser.BaseDirectory,
 			Target:        fields[1],
-			Version:       fields[2],
 		}, nil
 	default:
 		return nil, &ParseError{StatusCode: 501, Reason: "Not Implemented"}

--- a/http/request.go
+++ b/http/request.go
@@ -32,11 +32,9 @@ func parseRequestLine(reader *bufio.Reader) (*GetRequest, *ParseError) {
 		return nil, &ParseError{StatusCode: 400, Reason: "Bad Request"}
 	}
 
-	method := fields[0]
-	switch method {
+	switch fields[0] {
 	case "GET":
 		return &GetRequest{
-			Method:  method,
 			Target:  fields[1],
 			Version: fields[2],
 		}, nil

--- a/http/request.go
+++ b/http/request.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"bufio"
-	"fmt"
 	"strings"
 )
 
@@ -76,27 +75,6 @@ func readCRLFLine(reader *bufio.Reader) (string, error) {
 
 type Request interface {
 	Handle(connWriter *bufio.Writer) error
-}
-
-type GetRequest struct {
-	Method  string
-	Target  string
-	Version string
-}
-
-func (request *GetRequest) Handle(conn *bufio.Writer) error {
-	switch request.Target {
-	case "/":
-		fmt.Fprint(conn, "HTTP/1.1 200 OK\r\n")
-		fmt.Fprint(conn, "Content-Length: 5\r\n")
-		fmt.Fprint(conn, "Content-Type: text/plain\r\n")
-		fmt.Fprint(conn, "\r\n")
-		fmt.Fprintf(conn, "hello")
-		return nil
-	default:
-		fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")
-		return nil
-	}
 }
 
 type MissingEndOfHeaderCRLF struct{}

--- a/http/request.go
+++ b/http/request.go
@@ -32,7 +32,7 @@ func parseRequestLine(reader *bufio.Reader) (*GetRequest, *ParseError) {
 		return nil, &ParseError{StatusCode: 400, Reason: "Bad Request"}
 	}
 
-	switch fields[0] {
+	switch fields[0] { //TODO KDK: Set the base path
 	case "GET":
 		return &GetRequest{
 			Target:  fields[1],

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -17,7 +17,7 @@ var _ = Describe("RFC7230RequestParser", func() {
 		var (
 			parser  *http.RFC7230RequestParser
 			request http.Request
-			err     *http.ParseError
+			err     http.Response
 		)
 
 		BeforeEach(func() {

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -98,7 +98,7 @@ var _ = Describe("RFC7230RequestParser", func() {
 
 		Context("given any other request method", func() {
 			It("returns a ParseError with 501 Not Implemented", func() {
-				request, err = parser.ParseRequest(makeReader("GET / HTTP/1.1\r\n\n"))
+				request, err = parser.ParseRequest(makeReader("get / HTTP/1.1\r\n\n"))
 				Expect(err).To(BeEquivalentTo(&http.ParseError{
 					StatusCode: 501,
 					Reason:     "Not Implemented"}))

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -84,7 +84,7 @@ var _ = Describe("RFC7230RequestParser", func() {
 			It("returns a GetRequest containing the contents of the request", func() {
 				Expect(request).To(BeEquivalentTo(&http.GetRequest{
 					BaseDirectory: "/public",
-					Target:  "/foo",
+					Target:        "/foo",
 				}))
 			})
 

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -81,7 +81,6 @@ var _ = Describe("RFC7230RequestParser", func() {
 
 			It("returns a GetRequest containing the contents of the request", func() {
 				Expect(request).To(BeEquivalentTo(&http.GetRequest{
-					Method:  "GET",
 					Target:  "/foo",
 					Version: "HTTP/1.1",
 				}))

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -17,7 +17,7 @@ var _ = Describe("RFC7230RequestParser", func() {
 		var (
 			parser  *http.RFC7230RequestParser
 			reader  *bufio.Reader
-			request *http.Request
+			request http.Request
 			err     *http.ParseError
 		)
 
@@ -68,14 +68,17 @@ var _ = Describe("RFC7230RequestParser", func() {
 		})
 
 		Context("given a well-formed request", func() {
+			var typedRequest *http.GetRequest
+
 			BeforeEach(func() {
 				buffer := bytes.NewBufferString("GET /foo HTTP/1.1\r\nAccept: */*\r\n\r\n")
 				reader = bufio.NewReader(buffer)
 				request, err = parser.ParseRequest(reader)
+				typedRequest = request.(*http.GetRequest)
 			})
 
 			It("parses the request", func() {
-				Expect(request).To(BeEquivalentTo(&http.Request{
+				Expect(request).To(BeEquivalentTo(&http.GetRequest{
 					Method:  "GET",
 					Target:  "/foo",
 					Version: "HTTP/1.1",

--- a/http/request_test.go
+++ b/http/request_test.go
@@ -85,7 +85,6 @@ var _ = Describe("RFC7230RequestParser", func() {
 				Expect(request).To(BeEquivalentTo(&http.GetRequest{
 					BaseDirectory: "/public",
 					Target:  "/foo",
-					Version: "HTTP/1.1",
 				}))
 			})
 

--- a/http/server.go
+++ b/http/server.go
@@ -10,7 +10,7 @@ func MakeTCPServerOnAvailablePort(contentRootDirectory string, host string) *TCP
 	return &TCPServer{
 		Host:   host,
 		Port:   0,
-		Parser: RFC7230RequestParser{},
+		Parser: RFC7230RequestParser{BaseDirectory: contentRootDirectory},
 	}
 }
 
@@ -18,7 +18,7 @@ func MakeTCPServer(contentRootDirectory string, host string, port uint16) *TCPSe
 	return &TCPServer{
 		Host:   host,
 		Port:   port,
-		Parser: RFC7230RequestParser{},
+		Parser: RFC7230RequestParser{BaseDirectory: contentRootDirectory},
 	}
 }
 
@@ -93,7 +93,7 @@ func (server TCPServer) handleConnection(conn *net.TCPConn) {
 
 	writer := bufio.NewWriter(conn)
 	_ = request.Handle(writer) //TODO KDK: Write a test for the error case
-	_ = writer.Flush() //TODO KDK: May not be necessary.  But then again, it doesn't hurt.
+	_ = writer.Flush()         //TODO KDK: May not be necessary.  But then again, it doesn't hurt.
 }
 
 func (server *TCPServer) Shutdown() error {

--- a/http/server.go
+++ b/http/server.go
@@ -22,6 +22,12 @@ func MakeTCPServer(contentRootDirectory string, host string, port uint16) Server
 	}
 }
 
+type Server interface {
+	Address() net.Addr
+	Start() error
+	Shutdown() error
+}
+
 /* TCPServer */
 
 type TCPServer struct {
@@ -105,12 +111,4 @@ func (server *TCPServer) Shutdown() error {
 		server.listener = nil
 	}()
 	return server.listener.Close()
-}
-
-/* Server */
-
-type Server interface {
-	Address() net.Addr
-	Start() error
-	Shutdown() error
 }

--- a/http/server.go
+++ b/http/server.go
@@ -92,7 +92,7 @@ func (server TCPServer) handleConnection(conn *net.TCPConn) {
 	}
 
 	writer := bufio.NewWriter(conn)
-	_ = request.Handle(writer)
+	_ = request.Handle(writer) //TODO KDK: Write a test for the error case
 	_ = writer.Flush()
 }
 

--- a/http/server.go
+++ b/http/server.go
@@ -91,16 +91,9 @@ func (server TCPServer) handleConnection(conn *net.TCPConn) {
 		return
 	}
 
-	switch request.Target {
-	case "/":
-		fmt.Fprint(conn, "HTTP/1.1 200 OK\r\n")
-		fmt.Fprint(conn, "Content-Length: 5\r\n")
-		fmt.Fprint(conn, "Content-Type: text/plain\r\n")
-		fmt.Fprint(conn, "\r\n")
-		fmt.Fprintf(conn, "hello")
-	default:
-		fmt.Fprint(conn, "HTTP/1.1 404 Not Found\r\n")
-	}
+	writer := bufio.NewWriter(conn)
+	_ = request.Handle(writer)
+	_ = writer.Flush()
 }
 
 func (server *TCPServer) Shutdown() error {

--- a/http/server.go
+++ b/http/server.go
@@ -92,7 +92,12 @@ func (server TCPServer) handleConnection(conn *net.TCPConn) {
 	}
 
 	writer := bufio.NewWriter(conn)
-	_ = request.Handle(writer) //TODO KDK: Write a test for the error case
+	requestError := request.Handle(writer)
+	if requestError != nil {
+		fmt.Fprintf(conn, "HTTP/1.1 %d %s\r\n", 500, "Internal Server Error")
+		return
+	}
+
 	_ = writer.Flush()
 }
 

--- a/http/server.go
+++ b/http/server.go
@@ -106,3 +106,11 @@ func (server *TCPServer) Shutdown() error {
 	}()
 	return server.listener.Close()
 }
+
+type RequestParser interface {
+	ParseRequest(reader *bufio.Reader) (Request, *ParseError)
+}
+
+type Request interface {
+	Handle(connWriter *bufio.Writer) error
+}

--- a/http/server.go
+++ b/http/server.go
@@ -88,7 +88,7 @@ func (server TCPServer) handleConnection(conn *net.TCPConn) {
 	reader := bufio.NewReader(conn)
 	request, parseError := server.Parser.ParseRequest(reader)
 	if parseError != nil {
-		fmt.Fprintf(conn, "HTTP/1.1 %d %s\r\n", parseError.StatusCode, parseError.Reason)
+		parseError.WriteTo(conn)
 		return
 	}
 
@@ -111,9 +111,13 @@ func (server *TCPServer) Shutdown() error {
 }
 
 type RequestParser interface {
-	ParseRequest(reader *bufio.Reader) (Request, *ParseError)
+	ParseRequest(reader *bufio.Reader) (ok Request, parseError Response)
 }
 
 type Request interface {
 	Handle(client io.Writer) error
+}
+
+type Response interface {
+	WriteTo(client io.Writer) error
 }

--- a/http/server.go
+++ b/http/server.go
@@ -93,7 +93,7 @@ func (server TCPServer) handleConnection(conn *net.TCPConn) {
 
 	writer := bufio.NewWriter(conn)
 	_ = request.Handle(writer) //TODO KDK: Write a test for the error case
-	_ = writer.Flush()         //TODO KDK: May not be necessary.  But then again, it doesn't hurt.
+	_ = writer.Flush()
 }
 
 func (server *TCPServer) Shutdown() error {

--- a/http/server.go
+++ b/http/server.go
@@ -93,7 +93,7 @@ func (server TCPServer) handleConnection(conn *net.TCPConn) {
 
 	writer := bufio.NewWriter(conn)
 	_ = request.Handle(writer) //TODO KDK: Write a test for the error case
-	_ = writer.Flush()
+	_ = writer.Flush() //TODO KDK: May not be necessary.  But then again, it doesn't hurt.
 }
 
 func (server *TCPServer) Shutdown() error {

--- a/http/server.go
+++ b/http/server.go
@@ -6,7 +6,7 @@ import (
 	"net"
 )
 
-func MakeTCPServerOnAvailablePort(contentRootDirectory string, host string) Server {
+func MakeTCPServerOnAvailablePort(contentRootDirectory string, host string) *TCPServer {
 	return &TCPServer{
 		Host:   host,
 		Port:   0,
@@ -14,18 +14,12 @@ func MakeTCPServerOnAvailablePort(contentRootDirectory string, host string) Serv
 	}
 }
 
-func MakeTCPServer(contentRootDirectory string, host string, port uint16) Server {
+func MakeTCPServer(contentRootDirectory string, host string, port uint16) *TCPServer {
 	return &TCPServer{
 		Host:   host,
 		Port:   port,
 		Parser: RFC7230RequestParser{},
 	}
-}
-
-type Server interface {
-	Address() net.Addr
-	Start() error
-	Shutdown() error
 }
 
 /* TCPServer */

--- a/http/server.go
+++ b/http/server.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net"
 )
 
@@ -91,14 +92,11 @@ func (server TCPServer) handleConnection(conn *net.TCPConn) {
 		return
 	}
 
-	writer := bufio.NewWriter(conn)
-	requestError := request.Handle(writer)
+	requestError := request.Handle(conn)
 	if requestError != nil {
 		fmt.Fprintf(conn, "HTTP/1.1 %d %s\r\n", 500, "Internal Server Error")
 		return
 	}
-
-	_ = writer.Flush()
 }
 
 func (server *TCPServer) Shutdown() error {
@@ -117,5 +115,5 @@ type RequestParser interface {
 }
 
 type Request interface {
-	Handle(connWriter *bufio.Writer) error
+	Handle(client io.Writer) error
 }

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kkrull/gohttp/http"
 	"github.com/kkrull/gohttp/mock"
+	"github.com/kkrull/gohttp/response"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -209,7 +210,7 @@ var _ = Describe("TCPServer", func() {
 		Context("when the RequestParser returns an error", func() {
 			BeforeEach(func(done Done) {
 				parser = &mock.RequestParser{
-					ReturnsError: &http.ParseError{StatusCode: 400, Reason: "Bad Request"}}
+					ReturnsError: &response.BadRequest{DisplayText: "bang"}}
 				server = &http.TCPServer{
 					Host:   "localhost",
 					Parser: parser}

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -198,7 +198,7 @@ var _ = Describe("TCPServer", func() {
 				close(done)
 			})
 
-			It("parses the request line as everything up to the first CRLF", func(done Done) {
+			It("parses the request with the given RequestParser", func(done Done) {
 				writeString(conn, "GET / HTTP/1.1\r\n\r\n")
 				readString(conn)
 				parser.VerifyReceived([]byte("GET / HTTP/1.1\r\n"))
@@ -206,7 +206,7 @@ var _ = Describe("TCPServer", func() {
 			})
 		})
 
-		Context("when the request parser returns an error", func() {
+		Context("when the RequestParser returns an error", func() {
 			BeforeEach(func(done Done) {
 				parser = &mock.RequestParser{
 					ReturnsError: &http.ParseError{StatusCode: 400, Reason: "Bad Request"}}
@@ -223,6 +223,29 @@ var _ = Describe("TCPServer", func() {
 			It("responds with an HTTP status line of the status code and reason returned by the parser", func(done Done) {
 				writeString(conn, "GET / HTTP/1.1\r\n\r\n")
 				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 400 Bad Request\r\n"))
+				close(done)
+			})
+		})
+
+		Context("when there is an error handling the request", func() {
+			var request *mock.Request
+
+			BeforeEach(func(done Done) {
+				request = &mock.Request{ReturnsError: "bang"}
+				parser = &mock.RequestParser{ReturnsRequest: request}
+				server = &http.TCPServer{
+					Host:   "localhost",
+					Parser: parser}
+
+				Expect(server.Start()).To(Succeed())
+				conn, connectError = net.Dial("tcp", server.Address().String())
+				Expect(connectError).NotTo(HaveOccurred())
+				close(done)
+			})
+
+			It("responds with 500 Internal Server Error", func(done Done) {
+				writeString(conn, "GET /bang HTTP/1.1\r\n\r\n")
+				Expect(readString(conn)).To(HavePrefix("HTTP/1.1 500 Internal Server Error\r\n"))
 				close(done)
 			})
 		})

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	server       http.Server
+	server       *http.TCPServer
 	conn         net.Conn
 	connectError error
 

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -187,7 +187,7 @@ var _ = Describe("TCPServer", func() {
 
 		Context("when it receives a request", func() {
 			BeforeEach(func(done Done) {
-				parser = &mock.RequestParser{ReturnsRequest: &http.Request{}}
+				parser = &mock.RequestParser{ReturnsRequest: &http.GetRequest{}}
 				server = &http.TCPServer{
 					Host:   "localhost",
 					Parser: parser}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/signal"
 
@@ -111,15 +112,21 @@ func (command HelpCommand) Run(stderr io.Writer) (code int, err error) {
 
 /* RunServerCommand */
 
-func NewRunServerCommand(server http.Server) (command CliCommand, quit chan bool) {
+func NewRunServerCommand(server Server) (command CliCommand, quit chan bool) {
 	quit = make(chan bool, 1)
 	command = RunServerCommand{Server: server, quit: quit}
 	return
 }
 
 type RunServerCommand struct {
-	Server http.Server
+	Server Server
 	quit   <-chan bool
+}
+
+type Server interface {
+	Address() net.Addr
+	Start() error
+	Shutdown() error
 }
 
 func (command RunServerCommand) Run(stderr io.Writer) (code int, err error) {

--- a/mock/http_mocks.go
+++ b/mock/http_mocks.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net"
 
 	"github.com/kkrull/gohttp/http"
@@ -37,7 +38,7 @@ type Request struct {
 	ReturnsError string
 }
 
-func (mock Request) Handle(connWriter *bufio.Writer) error {
+func (mock Request) Handle(connWriter io.Writer) error {
 	if mock.ReturnsError != "" {
 		return fmt.Errorf(mock.ReturnsError)
 	}

--- a/mock/http_mocks.go
+++ b/mock/http_mocks.go
@@ -33,6 +33,18 @@ func (parser RequestParser) VerifyReceived(expected []byte) {
 	Expect(parser.received).To(Equal(expected))
 }
 
+type Request struct {
+	ReturnsError string
+}
+
+func (mock Request) Handle(connWriter *bufio.Writer) error {
+	if mock.ReturnsError != "" {
+		return fmt.Errorf(mock.ReturnsError)
+	}
+
+	return nil
+}
+
 type Server struct {
 	StartFails  string
 	startCalled bool

--- a/mock/http_mocks.go
+++ b/mock/http_mocks.go
@@ -12,11 +12,11 @@ import (
 
 type RequestParser struct {
 	ReturnsRequest http.Request
-	ReturnsError   *http.ParseError
+	ReturnsError   http.Response
 	received       []byte
 }
 
-func (parser *RequestParser) ParseRequest(reader *bufio.Reader) (http.Request, *http.ParseError) {
+func (parser *RequestParser) ParseRequest(reader *bufio.Reader) (http.Request, http.Response) {
 	allButLF, _ := reader.ReadBytes(byte('\r'))
 	shouldBeLF, _ := reader.ReadByte()
 	parser.received = appendByte(allButLF, shouldBeLF)

--- a/mock/http_mocks.go
+++ b/mock/http_mocks.go
@@ -10,12 +10,12 @@ import (
 )
 
 type RequestParser struct {
-	ReturnsRequest *http.Request
+	ReturnsRequest http.Request
 	ReturnsError   *http.ParseError
 	received       []byte
 }
 
-func (parser *RequestParser) ParseRequest(reader *bufio.Reader) (*http.Request, *http.ParseError) {
+func (parser *RequestParser) ParseRequest(reader *bufio.Reader) (http.Request, *http.ParseError) {
 	allButLF, _ := reader.ReadBytes(byte('\r'))
 	shouldBeLF, _ := reader.ReadByte()
 	parser.received = appendByte(allButLF, shouldBeLF)

--- a/response/responses.go
+++ b/response/responses.go
@@ -1,0 +1,24 @@
+package response
+
+import (
+	"fmt"
+	"io"
+)
+
+type BadRequest struct {
+	DisplayText string
+}
+
+func (response BadRequest) WriteTo(client io.Writer) error {
+	fmt.Fprintf(client, "HTTP/1.1 %d %s\r\n", 400, "Bad Request")
+	return nil
+}
+
+type NotImplemented struct {
+	Method string
+}
+
+func (response NotImplemented) WriteTo(client io.Writer) error {
+	fmt.Fprintf(client, "HTTP/1.1 %d %s\r\n", 501, "Not Implemented")
+	return nil
+}


### PR DESCRIPTION
Handling basic GET requests.  The main points of this PR are:

- The hard-coded responses that were part of `http.TCPServer` are now delegated to types in `http/get_request.go`
- Some interfaces that were declared next to the implementation have been moved to their point of use.
