### PR TITLE
Standardized routes

### DIFF
--- a/capability/capability_suite_test.go
+++ b/capability/capability_suite_test.go
@@ -13,14 +13,14 @@ func TestCapability(t *testing.T) {
 	RunSpecs(t, "capability")
 }
 
-type ServerCapabilityControllerMock struct {
+type ServerCapabilityServerMock struct {
 	optionsCalled bool
 }
 
-func (mock *ServerCapabilityControllerMock) Options(writer io.Writer) {
+func (mock *ServerCapabilityServerMock) Options(writer io.Writer) {
 	mock.optionsCalled = true
 }
 
-func (mock *ServerCapabilityControllerMock) OptionsShouldHaveBeenCalled() {
+func (mock *ServerCapabilityServerMock) OptionsShouldHaveBeenCalled() {
 	ExpectWithOffset(1, mock.optionsCalled).To(BeTrue())
 }

--- a/capability/route.go
+++ b/capability/route.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/msg/clienterror"
 )
 
 func NewRoute() *ServerCapabilityRoute {
@@ -19,11 +20,13 @@ type ServerCapabilityRoute struct {
 }
 
 func (route *ServerCapabilityRoute) Route(requested *http.RequestLine) http.Request {
-	if requested.Method == "OPTIONS" && requested.Target == "*" {
-		return &optionsRequest{Controller: route.Controller}
+	if requested.Target != "*" {
+		return nil
+	} else if requested.Method != "OPTIONS" {
+		return clienterror.MethodNotAllowed("OPTIONS")
 	}
-
-	return nil
+	
+	return &optionsRequest{Controller: route.Controller}
 }
 
 type optionsRequest struct {

--- a/capability/route.go
+++ b/capability/route.go
@@ -8,7 +8,7 @@ import (
 )
 
 func NewRoute() *ServerCapabilityRoute {
-	controller := &StaticCapabilityController{
+	controller := &StaticCapabilityServer{
 		AvailableMethods: []string{"GET", "HEAD"},
 	}
 
@@ -16,7 +16,7 @@ func NewRoute() *ServerCapabilityRoute {
 }
 
 type ServerCapabilityRoute struct {
-	Controller ServerCapabilityController
+	Controller ServerResource
 }
 
 func (route *ServerCapabilityRoute) Route(requested *http.RequestLine) http.Request {
@@ -26,19 +26,19 @@ func (route *ServerCapabilityRoute) Route(requested *http.RequestLine) http.Requ
 		return clienterror.MethodNotAllowed("OPTIONS")
 	}
 
-	return &optionsRequest{Controller: route.Controller}
+	return &optionsRequest{Resource: route.Controller}
 }
 
 type optionsRequest struct {
-	Controller ServerCapabilityController
+	Resource ServerResource
 }
 
 func (request *optionsRequest) Handle(client io.Writer) error {
-	request.Controller.Options(client)
+	request.Resource.Options(client)
 	return nil
 }
 
 // Reports the global, generic capabilities of this server, without regard to resource or state
-type ServerCapabilityController interface {
+type ServerResource interface {
 	Options(writer io.Writer)
 }

--- a/capability/route.go
+++ b/capability/route.go
@@ -25,7 +25,7 @@ func (route *ServerCapabilityRoute) Route(requested *http.RequestLine) http.Requ
 	} else if requested.Method != "OPTIONS" {
 		return clienterror.MethodNotAllowed("OPTIONS")
 	}
-	
+
 	return &optionsRequest{Controller: route.Controller}
 }
 

--- a/capability/route_test.go
+++ b/capability/route_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kkrull/gohttp/capability"
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/msg/clienterror"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -39,17 +40,19 @@ var _ = Describe("ServerCapabilityRoute", func() {
 			router = &capability.ServerCapabilityRoute{Controller: controller}
 		})
 
-		It("routes OPTIONS * to ServerCapabilityController#Options", func() {
-			requested = &http.RequestLine{Method: "OPTIONS", Target: "*"}
-			routedRequest = router.Route(requested)
-			routedRequest.Handle(&bufio.Writer{})
-			controller.OptionsShouldHaveBeenCalled()
-		})
+		Context("when the target is *", func() {
+			It("routes OPTIONS to ServerCapabilityController", func() {
+				requested = &http.RequestLine{Method: "OPTIONS", Target: "*"}
+				routedRequest = router.Route(requested)
+				routedRequest.Handle(&bufio.Writer{})
+				controller.OptionsShouldHaveBeenCalled()
+			})
 
-		It("returns nil to pass on any other method", func() {
-			requested = &http.RequestLine{Method: "GET", Target: "*"}
-			routedRequest = router.Route(requested)
-			Expect(routedRequest).To(BeNil())
+			It("returns MethodNotAllowed for any other method", func() {
+				requested = &http.RequestLine{Method: "GET", Target: "*"}
+				routedRequest = router.Route(requested)
+				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("OPTIONS")))
+			})
 		})
 
 		It("returns nil to pass on any other target", func() {

--- a/capability/route_test.go
+++ b/capability/route_test.go
@@ -9,9 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-//Panics due to incomplete wiring are easy to cause due to Go's permissive struct declaration
-//and hard to root cause when the server goes down and starts refusing connections behind a FitNesse suite
-//that swallows console output from the server
 var _ = Describe("::NewRoute", func() {
 	It("configures the route with StaticCapabilityController", func() {
 		route := capability.NewRoute()

--- a/capability/route_test.go
+++ b/capability/route_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 var _ = Describe("::NewRoute", func() {
-	It("configures the route with StaticCapabilityController", func() {
+	It("configures the route with StaticCapabilityServer", func() {
 		route := capability.NewRoute()
-		Expect(route.Controller).To(BeAssignableToTypeOf(&capability.StaticCapabilityController{}))
+		Expect(route.Controller).To(BeAssignableToTypeOf(&capability.StaticCapabilityServer{}))
 	})
 
 	It("configures available methods to the server as GET and HEAD", func() {
 		route := capability.NewRoute()
 		Expect(route.Controller).To(BeEquivalentTo(
-			&capability.StaticCapabilityController{
+			&capability.StaticCapabilityServer{
 				AvailableMethods: []string{"GET", "HEAD"},
 			},
 		))
@@ -30,18 +30,18 @@ var _ = Describe("ServerCapabilityRoute", func() {
 	Describe("#Route", func() {
 		var (
 			router        http.Route
-			controller    *ServerCapabilityControllerMock
+			controller    *ServerCapabilityServerMock
 			requested     *http.RequestLine
 			routedRequest http.Request
 		)
 
 		BeforeEach(func() {
-			controller = &ServerCapabilityControllerMock{}
+			controller = &ServerCapabilityServerMock{}
 			router = &capability.ServerCapabilityRoute{Controller: controller}
 		})
 
 		Context("when the target is *", func() {
-			It("routes OPTIONS to ServerCapabilityController", func() {
+			It("routes OPTIONS to ServerResource", func() {
 				requested = &http.RequestLine{Method: "OPTIONS", Target: "*"}
 				routedRequest = router.Route(requested)
 				routedRequest.Handle(&bufio.Writer{})

--- a/capability/server_capability.go
+++ b/capability/server_capability.go
@@ -8,11 +8,11 @@ import (
 )
 
 // Reports on server capabilities that are defined during startup and do not change after that
-type StaticCapabilityController struct {
+type StaticCapabilityServer struct {
 	AvailableMethods []string
 }
 
-func (controller *StaticCapabilityController) Options(client io.Writer) {
+func (controller *StaticCapabilityServer) Options(client io.Writer) {
 	msg.WriteStatusLine(client, 200, "OK")
 	msg.WriteHeader(client, "Allow", strings.Join(controller.AvailableMethods, ","))
 	msg.WriteContentLengthHeader(client, 0)

--- a/capability/server_capability_test.go
+++ b/capability/server_capability_test.go
@@ -9,9 +9,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("StaticCapabilityController", func() {
+var _ = Describe("StaticCapabilityServer", func() {
 	var (
-		controller     capability.ServerCapabilityController
+		controller     capability.ServerResource
 		response       *httptest.ResponseMessage
 		responseBuffer *bytes.Buffer
 	)
@@ -19,7 +19,7 @@ var _ = Describe("StaticCapabilityController", func() {
 	Describe("#Options", func() {
 		BeforeEach(func() {
 			responseBuffer = &bytes.Buffer{}
-			controller = &capability.StaticCapabilityController{
+			controller = &capability.StaticCapabilityServer{
 				AvailableMethods: []string{"CONNECT", "TRACE"},
 			}
 			controller.Options(responseBuffer)
@@ -39,7 +39,7 @@ var _ = Describe("StaticCapabilityController", func() {
 		Context("given 1 available method", func() {
 			BeforeEach(func() {
 				responseBuffer = &bytes.Buffer{}
-				controller = &capability.StaticCapabilityController{
+				controller = &capability.StaticCapabilityServer{
 					AvailableMethods: []string{"OPTIONS"},
 				}
 				controller.Options(responseBuffer)
@@ -54,7 +54,7 @@ var _ = Describe("StaticCapabilityController", func() {
 		Context("given 2 or more available methods", func() {
 			BeforeEach(func() {
 				responseBuffer = &bytes.Buffer{}
-				controller = &capability.StaticCapabilityController{
+				controller = &capability.StaticCapabilityServer{
 					AvailableMethods: []string{"CONNECT", "TRACE"},
 				}
 				controller.Options(responseBuffer)

--- a/fs/fs_suite_test.go
+++ b/fs/fs_suite_test.go
@@ -18,6 +18,10 @@ type FileSystemResourceMock struct {
 	headTarget string
 }
 
+func (mock *FileSystemResourceMock) Name() string {
+	return "File system mock"
+}
+
 func (mock *FileSystemResourceMock) Get(client io.Writer, target string) {
 	mock.getTarget = target
 }

--- a/fs/requests.go
+++ b/fs/requests.go
@@ -14,6 +14,10 @@ type ReadOnlyFileSystem struct {
 	BaseDirectory string
 }
 
+func (controller *ReadOnlyFileSystem) Name() string {
+	return "Readonly file system"
+}
+
 func (controller *ReadOnlyFileSystem) Get(client io.Writer, target string) {
 	response := controller.determineResponse(target)
 	response.WriteTo(client)

--- a/fs/requests.go
+++ b/fs/requests.go
@@ -10,21 +10,21 @@ import (
 	"github.com/kkrull/gohttp/msg/clienterror"
 )
 
-type ReadOnlyFilesystem struct {
+type ReadOnlyFileSystem struct {
 	BaseDirectory string
 }
 
-func (controller *ReadOnlyFilesystem) Get(client io.Writer, target string) {
+func (controller *ReadOnlyFileSystem) Get(client io.Writer, target string) {
 	response := controller.determineResponse(target)
 	response.WriteTo(client)
 }
 
-func (controller *ReadOnlyFilesystem) Head(client io.Writer, target string) {
+func (controller *ReadOnlyFileSystem) Head(client io.Writer, target string) {
 	response := controller.determineResponse(target)
 	response.WriteHeader(client)
 }
 
-func (controller *ReadOnlyFilesystem) determineResponse(requestedTarget string) http.Response {
+func (controller *ReadOnlyFileSystem) determineResponse(requestedTarget string) http.Response {
 	resolvedTarget := path.Join(controller.BaseDirectory, requestedTarget)
 	info, err := os.Stat(resolvedTarget)
 	if err != nil {

--- a/fs/requests_test.go
+++ b/fs/requests_test.go
@@ -12,9 +12,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ReadOnlyFilesystem", func() {
+var _ = Describe("ReadOnlyFileSystem", func() {
 	var (
-		controller *fs.ReadOnlyFilesystem
+		controller *fs.ReadOnlyFileSystem
 		basePath   string
 
 		response       *httptest.ResponseMessage
@@ -22,8 +22,8 @@ var _ = Describe("ReadOnlyFilesystem", func() {
 	)
 
 	BeforeEach(func() {
-		basePath = makeEmptyTestDirectory("ReadOnlyFilesystem", os.ModePerm)
-		controller = &fs.ReadOnlyFilesystem{BaseDirectory: basePath}
+		basePath = makeEmptyTestDirectory("ReadOnlyFileSystem", os.ModePerm)
+		controller = &fs.ReadOnlyFileSystem{BaseDirectory: basePath}
 		responseBuffer = &bytes.Buffer{}
 	})
 

--- a/fs/route.go
+++ b/fs/route.go
@@ -4,7 +4,6 @@ import (
 	"io"
 
 	"github.com/kkrull/gohttp/http"
-	"github.com/kkrull/gohttp/msg/clienterror"
 )
 
 func NewRoute(contentRootPath string) http.Route {
@@ -20,44 +19,12 @@ type FileSystemRoute struct {
 }
 
 func (route FileSystemRoute) Route(requested *http.RequestLine) http.Request {
-	switch requested.Method { //TODO KDK: Call MakeResourceRequest
-	case "GET":
-		return &GetRequest{
-			Controller: route.Resource,
-			Target:     requested.Target,
-		}
-	case "HEAD":
-		return &HeadRequest{
-			Controller: route.Resource,
-			Target:     requested.Target,
-		}
-	default:
-		return clienterror.MethodNotAllowed("GET", "HEAD")
-	}
+	return http.MakeResourceRequest(requested, route.Resource)
 }
 
 // Represents files and directories on the file system
 type FileSystemResource interface {
+	Name() string
 	Get(client io.Writer, target string)
 	Head(client io.Writer, target string)
-}
-
-type GetRequest struct {
-	Controller FileSystemResource
-	Target     string
-}
-
-func (request *GetRequest) Handle(client io.Writer) error {
-	request.Controller.Get(client, request.Target)
-	return nil
-}
-
-type HeadRequest struct {
-	Controller FileSystemResource
-	Target     string
-}
-
-func (request *HeadRequest) Handle(client io.Writer) error {
-	request.Controller.Head(client, request.Target)
-	return nil
 }

--- a/fs/route.go
+++ b/fs/route.go
@@ -32,7 +32,7 @@ func (route FileSystemRoute) Route(requested *http.RequestLine) http.Request {
 			Target:     requested.Target,
 		}
 	default:
-		return &clienterror.MethodNotAllowed{SupportedMethods: []string{"GET", "HEAD"}}
+		return clienterror.MethodNotAllowed("GET", "HEAD")
 	}
 }
 

--- a/fs/route.go
+++ b/fs/route.go
@@ -2,10 +2,9 @@ package fs
 
 import (
 	"io"
-	"strings"
 
 	"github.com/kkrull/gohttp/http"
-	"github.com/kkrull/gohttp/msg"
+	"github.com/kkrull/gohttp/msg/clienterror"
 )
 
 func NewRoute(contentRootPath string) http.Route {
@@ -33,7 +32,7 @@ func (route FileSystemRoute) Route(requested *http.RequestLine) http.Request {
 			Target:     requested.Target,
 		}
 	default:
-		return &MethodNotAllowedRequest{SupportedMethods: []string{"GET", "HEAD"}}
+		return &clienterror.MethodNotAllowed{SupportedMethods: []string{"GET", "HEAD"}}
 	}
 }
 
@@ -60,17 +59,5 @@ type HeadRequest struct {
 
 func (request *HeadRequest) Handle(client io.Writer) error {
 	request.Controller.Head(client, request.Target)
-	return nil
-}
-
-type MethodNotAllowedRequest struct {
-	SupportedMethods []string
-}
-
-func (notAllowed *MethodNotAllowedRequest) Handle(client io.Writer) error {
-	msg.WriteStatusLine(client, 405, "Method Not Allowed")
-	msg.WriteContentLengthHeader(client, 0)
-	msg.WriteHeader(client, "Allow", strings.Join(notAllowed.SupportedMethods, ","))
-	msg.WriteEndOfMessageHeader(client)
 	return nil
 }

--- a/fs/route.go
+++ b/fs/route.go
@@ -11,7 +11,7 @@ import (
 func NewRoute(contentRootPath string) http.Route {
 	return &FileSystemRoute{
 		ContentRootPath: contentRootPath,
-		Resource:        &ReadOnlyFilesystem{BaseDirectory: contentRootPath},
+		Resource:        &ReadOnlyFileSystem{BaseDirectory: contentRootPath},
 	}
 }
 
@@ -37,6 +37,7 @@ func (route FileSystemRoute) Route(requested *http.RequestLine) http.Request {
 	}
 }
 
+// Represents files and directories on the file system
 type FileSystemResource interface {
 	Get(client io.Writer, target string)
 	Head(client io.Writer, target string)

--- a/fs/route.go
+++ b/fs/route.go
@@ -20,7 +20,7 @@ type FileSystemRoute struct {
 }
 
 func (route FileSystemRoute) Route(requested *http.RequestLine) http.Request {
-	switch requested.Method {
+	switch requested.Method { //TODO KDK: Call MakeResourceRequest
 	case "GET":
 		return &GetRequest{
 			Controller: route.Resource,

--- a/fs/route_test.go
+++ b/fs/route_test.go
@@ -16,7 +16,7 @@ var _ = Describe("::NewRoute", func() {
 		Expect(route).To(BeEquivalentTo(
 			&fs.FileSystemRoute{
 				ContentRootPath: "/public",
-				Resource:        &fs.ReadOnlyFilesystem{BaseDirectory: "/public"},
+				Resource:        &fs.ReadOnlyFileSystem{BaseDirectory: "/public"},
 			}))
 	})
 })

--- a/fs/route_test.go
+++ b/fs/route_test.go
@@ -54,10 +54,7 @@ var _ = Describe("FileSystemRoute", func() {
 		It("routes any other method to MethodNotAllowed", func() {
 			requested := &http.RequestLine{Method: "TRACE", Target: "/"}
 			routedRequest := route.Route(requested)
-			Expect(routedRequest).To(BeEquivalentTo(
-				&clienterror.MethodNotAllowed{
-					SupportedMethods: []string{"GET", "HEAD"},
-				}))
+			Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET", "HEAD")))
 		})
 	})
 })

--- a/fs/route_test.go
+++ b/fs/route_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/kkrull/gohttp/fs"
 	"github.com/kkrull/gohttp/http"
-	"github.com/kkrull/gohttp/httptest"
+	"github.com/kkrull/gohttp/msg/clienterror"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -51,15 +51,13 @@ var _ = Describe("FileSystemRoute", func() {
 			resource.HeadShouldHaveReceived("/foo")
 		})
 
-		Context("given any other method", func() {
-			BeforeEach(func() {
-				requested := &http.RequestLine{Method: "TRACE", Target: "/"}
-				routedRequest := route.Route(requested)
-				routedRequest.Handle(response)
-			})
-
-			It("responds 405 Method Not Allowed", httptest.ShouldHaveNoBody(response, 405, "Method Not Allowed"))
-			It("sets Allow to GET and HEAD", httptest.ShouldAllowMethods(response, "GET", "HEAD"))
+		It("routes any other method to MethodNotAllowed", func() {
+			requested := &http.RequestLine{Method: "TRACE", Target: "/"}
+			routedRequest := route.Route(requested)
+			Expect(routedRequest).To(BeEquivalentTo(
+				&clienterror.MethodNotAllowed{
+					SupportedMethods: []string{"GET", "HEAD"},
+				}))
 		})
 	})
 })

--- a/fs/route_test.go
+++ b/fs/route_test.go
@@ -54,7 +54,7 @@ var _ = Describe("FileSystemRoute", func() {
 		It("routes any other method to MethodNotAllowed", func() {
 			requested := &http.RequestLine{Method: "TRACE", Target: "/"}
 			routedRequest := route.Route(requested)
-			Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET", "HEAD")))
+			Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET", "HEAD", "OPTIONS")))
 		})
 	})
 })

--- a/http/method_dispatcher.go
+++ b/http/method_dispatcher.go
@@ -6,9 +6,9 @@ import (
 	"github.com/kkrull/gohttp/msg/clienterror"
 )
 
-func MakeResourceRequest(requested *RequestLine, resource interface{}) Request {
+func MakeResourceRequest(requested *RequestLine, resource Resource) Request {
 	if requested.Method == "OPTIONS" {
-		return &knownOptionsRequest{
+		return &optionsRequest{
 			SupportedMethods: supportedMethods(requested.Target, resource),
 		}
 	}
@@ -26,15 +26,15 @@ func MakeResourceRequest(requested *RequestLine, resource interface{}) Request {
 	return request
 }
 
-func unknownHttpMethod(requested *RequestLine, resource interface{}) Request {
+func unknownHttpMethod(requested *RequestLine, resource Resource) Request {
 	return clienterror.MethodNotAllowed(supportedMethods(requested.Target, resource)...)
 }
 
-func unsupportedMethod(requested *RequestLine, resource interface{}) Request {
+func unsupportedMethod(requested *RequestLine, resource Resource) Request {
 	return clienterror.MethodNotAllowed(supportedMethods(requested.Target, resource)...)
 }
 
-func supportedMethods(target string, resource interface{}) []string {
+func supportedMethods(target string, resource Resource) []string {
 	supported := []string{"OPTIONS"}
 	for name, method := range knownMethods {
 		imaginaryRequest := &RequestLine{Method: name, Target: target}
@@ -56,5 +56,10 @@ var knownMethods = map[string]Method{
 }
 
 type Method interface {
-	MakeRequest(requested *RequestLine, resource interface{}) Request
+	MakeRequest(requested *RequestLine, resource Resource) Request
+}
+
+// Handles requests of supported HTTP methods for a resource
+type Resource interface {
+	Name() string
 }

--- a/http/method_dispatcher.go
+++ b/http/method_dispatcher.go
@@ -1,0 +1,60 @@
+package http
+
+import (
+	"sort"
+
+	"github.com/kkrull/gohttp/msg/clienterror"
+)
+
+func MakeResourceRequest(requested *RequestLine, resource interface{}) Request {
+	if requested.Method == "OPTIONS" {
+		return &knownOptionsRequest{
+			SupportedMethods: supportedMethods(requested.Target, resource),
+		}
+	}
+
+	method := knownMethods[requested.Method]
+	if method == nil {
+		return unknownHttpMethod(requested, resource)
+	}
+
+	request := method.MakeRequest(requested, resource)
+	if request == nil {
+		return unsupportedMethod(requested, resource)
+	}
+
+	return request
+}
+
+func unknownHttpMethod(requested *RequestLine, resource interface{}) Request {
+	return clienterror.MethodNotAllowed(supportedMethods(requested.Target, resource)...)
+}
+
+func unsupportedMethod(requested *RequestLine, resource interface{}) Request {
+	return clienterror.MethodNotAllowed(supportedMethods(requested.Target, resource)...)
+}
+
+func supportedMethods(target string, resource interface{}) []string {
+	supported := []string{"OPTIONS"}
+	for name, method := range knownMethods {
+		imaginaryRequest := &RequestLine{Method: name, Target: target}
+		request := method.MakeRequest(imaginaryRequest, resource)
+		if request != nil {
+			supported = append(supported, name)
+		}
+	}
+
+	sort.Strings(supported)
+	return supported
+}
+
+var knownMethods = map[string]Method{
+	"GET":  &getMethod{},
+	"HEAD": &headMethod{},
+	"POST": &postMethod{},
+	"PUT":  &putMethod{},
+}
+
+type Method interface {
+	MakeRequest(requested *RequestLine, resource interface{}) Request
+}

--- a/http/methods.go
+++ b/http/methods.go
@@ -22,7 +22,7 @@ func (method *getMethod) MakeRequest(requested *RequestLine, resource Resource) 
 
 type getRequest struct {
 	Resource GetResource
-	Target string
+	Target   string
 }
 
 func (request *getRequest) Handle(client io.Writer) error {
@@ -36,7 +36,7 @@ type GetResource interface {
 
 /* HEAD */
 
-type headMethod struct {}
+type headMethod struct{}
 
 func (*headMethod) MakeRequest(requested *RequestLine, resource Resource) Request {
 	supportedResource, ok := resource.(HeadResource)
@@ -49,7 +49,7 @@ func (*headMethod) MakeRequest(requested *RequestLine, resource Resource) Reques
 
 type headRequest struct {
 	Resource HeadResource
-	Target string
+	Target   string
 }
 
 func (request *headRequest) Handle(client io.Writer) error {
@@ -90,7 +90,7 @@ func (*postMethod) MakeRequest(requested *RequestLine, resource Resource) Reques
 
 type postRequest struct {
 	Resource PostResource
-	Target string
+	Target   string
 }
 
 func (request *postRequest) Handle(client io.Writer) error {
@@ -117,7 +117,7 @@ func (*putMethod) MakeRequest(requested *RequestLine, resource Resource) Request
 
 type putRequest struct {
 	Resource PutResource
-	Target string
+	Target   string
 }
 
 func (request *putRequest) Handle(client io.Writer) error {

--- a/http/methods.go
+++ b/http/methods.go
@@ -11,7 +11,7 @@ import (
 
 type getMethod struct{}
 
-func (method *getMethod) MakeRequest(requested *RequestLine, resource interface{}) Request {
+func (method *getMethod) MakeRequest(requested *RequestLine, resource Resource) Request {
 	supportedResource, ok := resource.(GetResource)
 	if ok {
 		return &getRequest{Resource: supportedResource}
@@ -39,7 +39,7 @@ type headMethod struct {
 	Resource HeadResource
 }
 
-func (*headMethod) MakeRequest(requested *RequestLine, resource interface{}) Request {
+func (*headMethod) MakeRequest(requested *RequestLine, resource Resource) Request {
 	supportedResource, ok := resource.(HeadResource)
 	if ok {
 		return &headRequest{Resource: supportedResource}
@@ -63,11 +63,11 @@ type HeadResource interface {
 
 /* OPTIONS */
 
-type knownOptionsRequest struct {
+type optionsRequest struct {
 	SupportedMethods []string
 }
 
-func (request *knownOptionsRequest) Handle(client io.Writer) error {
+func (request *optionsRequest) Handle(client io.Writer) error {
 	msg.WriteStatusLine(client, 200, "OK")
 	msg.WriteContentLengthHeader(client, 0)
 	msg.WriteHeader(client, "Allow", strings.Join(request.SupportedMethods, ","))
@@ -79,7 +79,7 @@ func (request *knownOptionsRequest) Handle(client io.Writer) error {
 
 type postMethod struct{}
 
-func (*postMethod) MakeRequest(requested *RequestLine, resource interface{}) Request {
+func (*postMethod) MakeRequest(requested *RequestLine, resource Resource) Request {
 	supportedResource, ok := resource.(PostResource)
 	if ok {
 		return &postRequest{Resource: supportedResource}
@@ -105,7 +105,7 @@ type PostResource interface {
 
 type putMethod struct{}
 
-func (*putMethod) MakeRequest(requested *RequestLine, resource interface{}) Request {
+func (*putMethod) MakeRequest(requested *RequestLine, resource Resource) Request {
 	supportedResource, ok := resource.(PutResource)
 	if ok {
 		return &putRequest{Resource: supportedResource}

--- a/http/methods.go
+++ b/http/methods.go
@@ -14,7 +14,7 @@ type getMethod struct{}
 func (method *getMethod) MakeRequest(requested *RequestLine, resource Resource) Request {
 	supportedResource, ok := resource.(GetResource)
 	if ok {
-		return &getRequest{Resource: supportedResource}
+		return &getRequest{Resource: supportedResource, Target: requested.Target}
 	}
 
 	return nil
@@ -22,27 +22,26 @@ func (method *getMethod) MakeRequest(requested *RequestLine, resource Resource) 
 
 type getRequest struct {
 	Resource GetResource
+	Target string
 }
 
 func (request *getRequest) Handle(client io.Writer) error {
-	request.Resource.Get(client)
+	request.Resource.Get(client, request.Target)
 	return nil
 }
 
 type GetResource interface {
-	Get(client io.Writer)
+	Get(client io.Writer, target string)
 }
 
 /* HEAD */
 
-type headMethod struct {
-	Resource HeadResource
-}
+type headMethod struct {}
 
 func (*headMethod) MakeRequest(requested *RequestLine, resource Resource) Request {
 	supportedResource, ok := resource.(HeadResource)
 	if ok {
-		return &headRequest{Resource: supportedResource}
+		return &headRequest{Resource: supportedResource, Target: requested.Target}
 	}
 
 	return nil
@@ -50,15 +49,16 @@ func (*headMethod) MakeRequest(requested *RequestLine, resource Resource) Reques
 
 type headRequest struct {
 	Resource HeadResource
+	Target string
 }
 
 func (request *headRequest) Handle(client io.Writer) error {
-	request.Resource.Head(client)
+	request.Resource.Head(client, request.Target)
 	return nil
 }
 
 type HeadResource interface {
-	Head(client io.Writer)
+	Head(client io.Writer, target string)
 }
 
 /* OPTIONS */
@@ -82,7 +82,7 @@ type postMethod struct{}
 func (*postMethod) MakeRequest(requested *RequestLine, resource Resource) Request {
 	supportedResource, ok := resource.(PostResource)
 	if ok {
-		return &postRequest{Resource: supportedResource}
+		return &postRequest{Resource: supportedResource, Target: requested.Target}
 	}
 
 	return nil
@@ -90,15 +90,16 @@ func (*postMethod) MakeRequest(requested *RequestLine, resource Resource) Reques
 
 type postRequest struct {
 	Resource PostResource
+	Target string
 }
 
 func (request *postRequest) Handle(client io.Writer) error {
-	request.Resource.Post(client)
+	request.Resource.Post(client, request.Target)
 	return nil
 }
 
 type PostResource interface {
-	Post(client io.Writer)
+	Post(client io.Writer, target string)
 }
 
 /* PUT */
@@ -108,7 +109,7 @@ type putMethod struct{}
 func (*putMethod) MakeRequest(requested *RequestLine, resource Resource) Request {
 	supportedResource, ok := resource.(PutResource)
 	if ok {
-		return &putRequest{Resource: supportedResource}
+		return &putRequest{Resource: supportedResource, Target: requested.Target}
 	}
 
 	return nil
@@ -116,13 +117,14 @@ func (*putMethod) MakeRequest(requested *RequestLine, resource Resource) Request
 
 type putRequest struct {
 	Resource PutResource
+	Target string
 }
 
 func (request *putRequest) Handle(client io.Writer) error {
-	request.Resource.Put(client)
+	request.Resource.Put(client, request.Target)
 	return nil
 }
 
 type PutResource interface {
-	Put(client io.Writer)
+	Put(client io.Writer, target string)
 }

--- a/http/methods.go
+++ b/http/methods.go
@@ -1,10 +1,9 @@
-package playground
+package http
 
 import (
 	"io"
 	"strings"
 
-	"github.com/kkrull/gohttp/http"
 	"github.com/kkrull/gohttp/msg"
 )
 
@@ -12,7 +11,7 @@ import (
 
 type getMethod struct{}
 
-func (method *getMethod) MakeRequest(requested *http.RequestLine, resource interface{}) http.Request {
+func (method *getMethod) MakeRequest(requested *RequestLine, resource interface{}) Request {
 	supportedResource, ok := resource.(GetResource)
 	if ok {
 		return &getRequest{Resource: supportedResource}
@@ -40,7 +39,7 @@ type headMethod struct {
 	Resource HeadResource
 }
 
-func (*headMethod) MakeRequest(requested *http.RequestLine, resource interface{}) http.Request {
+func (*headMethod) MakeRequest(requested *RequestLine, resource interface{}) Request {
 	supportedResource, ok := resource.(HeadResource)
 	if ok {
 		return &headRequest{Resource: supportedResource}
@@ -80,7 +79,7 @@ func (request *knownOptionsRequest) Handle(client io.Writer) error {
 
 type postMethod struct{}
 
-func (*postMethod) MakeRequest(requested *http.RequestLine, resource interface{}) http.Request {
+func (*postMethod) MakeRequest(requested *RequestLine, resource interface{}) Request {
 	supportedResource, ok := resource.(PostResource)
 	if ok {
 		return &postRequest{Resource: supportedResource}
@@ -106,7 +105,7 @@ type PostResource interface {
 
 type putMethod struct{}
 
-func (*putMethod) MakeRequest(requested *http.RequestLine, resource interface{}) http.Request {
+func (*putMethod) MakeRequest(requested *RequestLine, resource interface{}) Request {
 	supportedResource, ok := resource.(PutResource)
 	if ok {
 		return &putRequest{Resource: supportedResource}

--- a/msg/clienterror/client_requests.go
+++ b/msg/clienterror/client_requests.go
@@ -7,11 +7,15 @@ import (
 	"github.com/kkrull/gohttp/msg"
 )
 
-type MethodNotAllowed struct {
+func MethodNotAllowed(supportedMethods ...string) *methodNotAllowed {
+	return &methodNotAllowed{SupportedMethods: supportedMethods}
+}
+
+type methodNotAllowed struct {
 	SupportedMethods []string
 }
 
-func (notAllowed *MethodNotAllowed) Handle(client io.Writer) error {
+func (notAllowed *methodNotAllowed) Handle(client io.Writer) error {
 	msg.WriteStatusLine(client, 405, "Method Not Allowed")
 	msg.WriteContentLengthHeader(client, 0)
 	msg.WriteHeader(client, "Allow", strings.Join(notAllowed.SupportedMethods, ","))

--- a/msg/clienterror/client_requests.go
+++ b/msg/clienterror/client_requests.go
@@ -1,0 +1,20 @@
+package clienterror
+
+import (
+	"io"
+	"strings"
+
+	"github.com/kkrull/gohttp/msg"
+)
+
+type MethodNotAllowed struct {
+	SupportedMethods []string
+}
+
+func (notAllowed *MethodNotAllowed) Handle(client io.Writer) error {
+	msg.WriteStatusLine(client, 405, "Method Not Allowed")
+	msg.WriteContentLengthHeader(client, 0)
+	msg.WriteHeader(client, "Allow", strings.Join(notAllowed.SupportedMethods, ","))
+	msg.WriteEndOfMessageHeader(client)
+	return nil
+}

--- a/msg/clienterror/client_requests_test.go
+++ b/msg/clienterror/client_requests_test.go
@@ -18,7 +18,7 @@ var _ = Describe("MethodNotAllowed", func() {
 	Describe("#Handle", func() {
 		BeforeEach(func() {
 			response.Reset()
-			request = &clienterror.MethodNotAllowed{SupportedMethods: []string{"GET", "HEAD"}}
+			request = clienterror.MethodNotAllowed("GET", "HEAD")
 			request.Handle(response)
 		})
 

--- a/msg/clienterror/client_requests_test.go
+++ b/msg/clienterror/client_requests_test.go
@@ -1,0 +1,28 @@
+package clienterror_test
+
+import (
+	"bytes"
+
+	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/httptest"
+	"github.com/kkrull/gohttp/msg/clienterror"
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("MethodNotAllowed", func() {
+	var (
+		request  http.Request
+		response = &bytes.Buffer{}
+	)
+
+	Describe("#Handle", func() {
+		BeforeEach(func() {
+			response.Reset()
+			request = &clienterror.MethodNotAllowed{SupportedMethods: []string{"GET", "HEAD"}}
+			request.Handle(response)
+		})
+
+		It("responds 405 Method Not Allowed", httptest.ShouldHaveNoBody(response, 405, "Method Not Allowed"))
+		It("sets Allow to GET and HEAD", httptest.ShouldAllowMethods(response, "GET", "HEAD"))
+	})
+})

--- a/msg/clienterror/clienterror_suite_test.go
+++ b/msg/clienterror/clienterror_suite_test.go
@@ -1,0 +1,13 @@
+package clienterror_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMsgClientError(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "msg/clienterror")
+}

--- a/playground/playground_suite_test.go
+++ b/playground/playground_suite_test.go
@@ -24,7 +24,7 @@ func (mock *ReadOnlyResourceMock) Name() string {
 	return "Readonly Mock"
 }
 
-func (mock *ReadOnlyResourceMock) Get(client io.Writer) {
+func (mock *ReadOnlyResourceMock) Get(client io.Writer, target string) {
 	mock.getCalled = true
 }
 
@@ -32,7 +32,7 @@ func (mock *ReadOnlyResourceMock) GetShouldHaveBeenCalled() {
 	ExpectWithOffset(1, mock.getCalled).To(BeTrue())
 }
 
-func (mock *ReadOnlyResourceMock) Head(client io.Writer) {
+func (mock *ReadOnlyResourceMock) Head(client io.Writer, target string) {
 	mock.headCalled = true
 }
 
@@ -53,7 +53,7 @@ func (mock *ReadWriteResourceMock) Name() string {
 	return "Read/Write Mock"
 }
 
-func (mock *ReadWriteResourceMock) Get(client io.Writer) {
+func (mock *ReadWriteResourceMock) Get(client io.Writer, target string) {
 	mock.getCalled = true
 }
 
@@ -61,7 +61,7 @@ func (mock *ReadWriteResourceMock) GetShouldHaveBeenCalled() {
 	ExpectWithOffset(1, mock.getCalled).To(BeTrue())
 }
 
-func (mock *ReadWriteResourceMock) Head(client io.Writer) {
+func (mock *ReadWriteResourceMock) Head(client io.Writer, target string) {
 	mock.headCalled = true
 }
 
@@ -69,7 +69,7 @@ func (mock *ReadWriteResourceMock) HeadShouldHaveBeenCalled() {
 	ExpectWithOffset(1, mock.headCalled).To(BeTrue())
 }
 
-func (mock *ReadWriteResourceMock) Post(client io.Writer) {
+func (mock *ReadWriteResourceMock) Post(client io.Writer, target string) {
 	mock.postCalled = true
 }
 
@@ -77,7 +77,7 @@ func (mock *ReadWriteResourceMock) PostShouldHaveBeenCalled() {
 	ExpectWithOffset(1, mock.postCalled).To(BeTrue())
 }
 
-func (mock *ReadWriteResourceMock) Put(client io.Writer) {
+func (mock *ReadWriteResourceMock) Put(client io.Writer, target string) {
 	mock.putCalled = true
 }
 

--- a/playground/playground_suite_test.go
+++ b/playground/playground_suite_test.go
@@ -20,6 +20,10 @@ type ReadOnlyResourceMock struct {
 	headCalled bool
 }
 
+func (mock *ReadOnlyResourceMock) Name() string {
+	return "Readonly Mock"
+}
+
 func (mock *ReadOnlyResourceMock) Get(client io.Writer) {
 	mock.getCalled = true
 }
@@ -43,6 +47,10 @@ type ReadWriteResourceMock struct {
 	headCalled bool
 	postCalled bool
 	putCalled  bool
+}
+
+func (mock *ReadWriteResourceMock) Name() string {
+	return "Read/Write Mock"
 }
 
 func (mock *ReadWriteResourceMock) Get(client io.Writer) {

--- a/playground/resources.go
+++ b/playground/resources.go
@@ -13,11 +13,11 @@ func (controller *ReadableNopResource) Name() string {
 	return "Readonly NOP"
 }
 
-func (controller *ReadableNopResource) Get(client io.Writer) {
-	controller.Head(client)
+func (controller *ReadableNopResource) Get(client io.Writer, target string) {
+	controller.Head(client, target)
 }
 
-func (controller *ReadableNopResource) Head(client io.Writer) {
+func (controller *ReadableNopResource) Head(client io.Writer, target string) {
 	writeOKWithNoBody(client)
 }
 
@@ -28,19 +28,19 @@ func (controller *ReadWriteNopResource) Name() string {
 	return "Read/Write NOP"
 }
 
-func (controller *ReadWriteNopResource) Get(client io.Writer) {
-	controller.Head(client)
+func (controller *ReadWriteNopResource) Get(client io.Writer, target string) {
+	controller.Head(client, target)
 }
 
-func (controller *ReadWriteNopResource) Head(client io.Writer) {
+func (controller *ReadWriteNopResource) Head(client io.Writer, target string) {
 	writeOKWithNoBody(client)
 }
 
-func (controller *ReadWriteNopResource) Post(client io.Writer) {
+func (controller *ReadWriteNopResource) Post(client io.Writer, target string) {
 	writeOKWithNoBody(client)
 }
 
-func (controller *ReadWriteNopResource) Put(client io.Writer) {
+func (controller *ReadWriteNopResource) Put(client io.Writer, target string) {
 	writeOKWithNoBody(client)
 }
 

--- a/playground/resources.go
+++ b/playground/resources.go
@@ -9,6 +9,10 @@ import (
 // Handles various read requests, but doesn't actually do anything
 type ReadableNopResource struct{}
 
+func (controller *ReadableNopResource) Name() string {
+	return "Readonly NOP"
+}
+
 func (controller *ReadableNopResource) Get(client io.Writer) {
 	controller.Head(client)
 }
@@ -19,6 +23,10 @@ func (controller *ReadableNopResource) Head(client io.Writer) {
 
 // Handles various read/write requests, but doesn't actually do anything
 type ReadWriteNopResource struct{}
+
+func (controller *ReadWriteNopResource) Name() string {
+	return "Read/Write NOP"
+}
 
 func (controller *ReadWriteNopResource) Get(client io.Writer) {
 	controller.Head(client)

--- a/playground/resources_test.go
+++ b/playground/resources_test.go
@@ -21,7 +21,7 @@ var _ = Describe("ReadableNopResource", func() {
 
 	Describe("#Get", func() {
 		BeforeEach(func() {
-			controller.Get(response)
+			controller.Get(response, "/")
 		})
 
 		It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
@@ -29,7 +29,7 @@ var _ = Describe("ReadableNopResource", func() {
 
 	Describe("#Head", func() {
 		BeforeEach(func() {
-			controller.Head(response)
+			controller.Head(response, "/")
 		})
 
 		It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
@@ -49,7 +49,7 @@ var _ = Describe("ReadWriteNopResource", func() {
 
 	Describe("#Get", func() {
 		BeforeEach(func() {
-			controller.Get(response)
+			controller.Get(response, "/")
 		})
 
 		It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
@@ -57,7 +57,7 @@ var _ = Describe("ReadWriteNopResource", func() {
 
 	Describe("#Head", func() {
 		BeforeEach(func() {
-			controller.Head(response)
+			controller.Head(response, "/")
 		})
 
 		It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
@@ -65,7 +65,7 @@ var _ = Describe("ReadWriteNopResource", func() {
 
 	Describe("#Post", func() {
 		BeforeEach(func() {
-			controller.Post(response)
+			controller.Post(response, "/")
 		})
 
 		It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
@@ -73,7 +73,7 @@ var _ = Describe("ReadWriteNopResource", func() {
 
 	Describe("#Put", func() {
 		BeforeEach(func() {
-			controller.Put(response)
+			controller.Put(response, "/")
 		})
 
 		It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))

--- a/playground/routes.go
+++ b/playground/routes.go
@@ -23,6 +23,7 @@ func (route *ReadOnlyRoute) Route(requested *http.RequestLine) http.Request {
 }
 
 type ReadOnlyResource interface {
+	Name() string
 	Get(client io.Writer)
 	Head(client io.Writer)
 }
@@ -46,6 +47,7 @@ func (route *ReadWriteRoute) Route(requested *http.RequestLine) http.Request {
 }
 
 type ReadWriteResource interface {
+	Name() string
 	Get(client io.Writer)
 	Head(client io.Writer)
 	Post(client io.Writer)

--- a/playground/routes.go
+++ b/playground/routes.go
@@ -24,8 +24,8 @@ func (route *ReadOnlyRoute) Route(requested *http.RequestLine) http.Request {
 
 type ReadOnlyResource interface {
 	Name() string
-	Get(client io.Writer)
-	Head(client io.Writer)
+	Get(client io.Writer, target string)
+	Head(client io.Writer, target string)
 }
 
 func NewReadWriteRoute() *ReadWriteRoute {
@@ -48,8 +48,8 @@ func (route *ReadWriteRoute) Route(requested *http.RequestLine) http.Request {
 
 type ReadWriteResource interface {
 	Name() string
-	Get(client io.Writer)
-	Head(client io.Writer)
-	Post(client io.Writer)
-	Put(client io.Writer)
+	Get(client io.Writer, target string)
+	Head(client io.Writer, target string)
+	Post(client io.Writer, target string)
+	Put(client io.Writer, target string)
 }

--- a/playground/routes_test.go
+++ b/playground/routes_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kkrull/gohttp/http"
 	"github.com/kkrull/gohttp/httptest"
+	"github.com/kkrull/gohttp/msg/clienterror"
 	"github.com/kkrull/gohttp/playground"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -58,10 +59,10 @@ var _ = Describe("ReadOnlyRoute", func() {
 					httptest.ShouldAllowMethods(response, "GET", "HEAD", "OPTIONS"))
 			})
 
-			It("returns nil for any other method", func() {
+			It("returns MethodNotAllowed for any other method", func() {
 				requested := &http.RequestLine{Method: "PUT", Target: "/method_options2"}
 				routedRequest := router.Route(requested)
-				Expect(routedRequest).To(BeNil())
+				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET", "HEAD", "OPTIONS")))
 			})
 		})
 
@@ -131,10 +132,10 @@ var _ = Describe("ReadWriteRoute", func() {
 				resource.PutShouldHaveBeenCalled()
 			})
 
-			It("returns nil on any other method", func() {
+			It("returns MethodNotAllowed for any other method", func() {
 				requested := &http.RequestLine{Method: "TRACE", Target: "/method_options"}
 				routedRequest := router.Route(requested)
-				Expect(routedRequest).To(BeNil())
+				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET", "HEAD", "OPTIONS", "POST", "PUT")))
 			})
 		})
 

--- a/playground/routes_test.go
+++ b/playground/routes_test.go
@@ -21,24 +21,24 @@ var _ = Describe("::NewReadOnlyRoute", func() {
 var _ = Describe("ReadOnlyRoute", func() {
 	Describe("#Route", func() {
 		var (
-			router           http.Route
-			readOnlyResource *ReadOnlyResourceMock
+			router   http.Route
+			resource *ReadOnlyResourceMock
 		)
 
 		BeforeEach(func() {
-			readOnlyResource = &ReadOnlyResourceMock{}
-			router = &playground.ReadOnlyRoute{Resource: readOnlyResource}
+			resource = &ReadOnlyResourceMock{}
+			router = &playground.ReadOnlyRoute{Resource: resource}
 		})
 
 		Context("when the target is /method_options2", func() {
 			It("routes GET to Resource#Get", func() {
 				handleRequest(router, "GET", "/method_options2")
-				readOnlyResource.GetShouldHaveBeenCalled()
+				resource.GetShouldHaveBeenCalled()
 			})
 
 			It("routes HEAD to Resource#Options", func() {
 				handleRequest(router, "HEAD", "/method_options2")
-				readOnlyResource.HeadShouldHaveBeenCalled()
+				resource.HeadShouldHaveBeenCalled()
 			})
 
 			Context("when the method is OPTIONS", func() {
@@ -47,7 +47,7 @@ var _ = Describe("ReadOnlyRoute", func() {
 				BeforeEach(func() {
 					requested := &http.RequestLine{Method: "OPTIONS", Target: "/method_options2"}
 					routedRequest := router.Route(requested)
-					ExpectWithOffset(1, routedRequest).NotTo(BeNil())
+					Expect(routedRequest).NotTo(BeNil())
 
 					response.Reset()
 					routedRequest.Handle(response)
@@ -110,7 +110,7 @@ var _ = Describe("ReadWriteRoute", func() {
 				BeforeEach(func() {
 					requested := &http.RequestLine{Method: "OPTIONS", Target: "/method_options"}
 					routedRequest := router.Route(requested)
-					ExpectWithOffset(1, routedRequest).NotTo(BeNil())
+					Expect(routedRequest).NotTo(BeNil())
 
 					response.Reset()
 					routedRequest.Handle(response)

--- a/playground/routes_test.go
+++ b/playground/routes_test.go
@@ -32,12 +32,12 @@ var _ = Describe("ReadOnlyRoute", func() {
 		})
 
 		Context("when the target is /method_options2", func() {
-			It("routes GET to Resource#Get", func() {
+			It("routes GET to Teapot#Get", func() {
 				handleRequest(router, "GET", "/method_options2")
 				resource.GetShouldHaveBeenCalled()
 			})
 
-			It("routes HEAD to Resource#Options", func() {
+			It("routes HEAD to Teapot#Options", func() {
 				handleRequest(router, "HEAD", "/method_options2")
 				resource.HeadShouldHaveBeenCalled()
 			})
@@ -95,12 +95,12 @@ var _ = Describe("ReadWriteRoute", func() {
 		})
 
 		Context("when the target is /method_options", func() {
-			It("routes GET to Resource#Get", func() {
+			It("routes GET to Teapot#Get", func() {
 				handleRequest(router, "GET", "/method_options")
 				resource.GetShouldHaveBeenCalled()
 			})
 
-			It("routes HEAD to Resource#Head", func() {
+			It("routes HEAD to Teapot#Head", func() {
 				handleRequest(router, "HEAD", "/method_options")
 				resource.HeadShouldHaveBeenCalled()
 			})
@@ -122,12 +122,12 @@ var _ = Describe("ReadWriteRoute", func() {
 					httptest.ShouldAllowMethods(response, "GET", "HEAD", "OPTIONS", "POST", "PUT"))
 			})
 
-			It("routes POST to Resource#Post", func() {
+			It("routes POST to Teapot#Post", func() {
 				handleRequest(router, "POST", "/method_options")
 				resource.PostShouldHaveBeenCalled()
 			})
 
-			It("routes PUT to Resource#Put", func() {
+			It("routes PUT to Teapot#Put", func() {
 				handleRequest(router, "PUT", "/method_options")
 				resource.PutShouldHaveBeenCalled()
 			})

--- a/teapot/requests.go
+++ b/teapot/requests.go
@@ -6,24 +6,6 @@ import (
 	"github.com/kkrull/gohttp/msg"
 )
 
-type GetCoffeeRequest struct {
-	Controller Teapot
-}
-
-func (request *GetCoffeeRequest) Handle(client io.Writer) error {
-	request.Controller.GetCoffee(client)
-	return nil
-}
-
-type GetTeaRequest struct {
-	Controller Teapot
-}
-
-func (request *GetTeaRequest) Handle(client io.Writer) error {
-	request.Controller.GetTea(client)
-	return nil
-}
-
 // Responds as a teapot that is aware of its own identity
 type IdentityTeapot struct{}
 

--- a/teapot/requests.go
+++ b/teapot/requests.go
@@ -9,22 +9,22 @@ import (
 // Responds as a teapot that is aware of its own identity
 type IdentityTeapot struct{}
 
-func (controller *IdentityTeapot) Name() string {
+func (teapot *IdentityTeapot) Name() string {
 	return "teapot"
 }
 
-func (controller *IdentityTeapot) Get(client io.Writer, target string) {
+func (teapot *IdentityTeapot) Get(client io.Writer, target string) {
 	switch target {
 	case "/coffee":
-		controller.GetCoffee(client)
+		teapot.getCoffee(client)
 	case "/tea":
-		controller.GetTea(client)
+		teapot.getTea(client)
 	default:
-		panic("unknown target")
+		panic("unknown target") //TODO KDK: Respond?
 	}
 }
 
-func (controller *IdentityTeapot) GetCoffee(client io.Writer) {
+func (teapot *IdentityTeapot) getCoffee(client io.Writer) {
 	body := "I'm a teapot"
 	writeHeaders(client, body)
 	msg.WriteBody(client, body)
@@ -37,7 +37,7 @@ func writeHeaders(client io.Writer, body string) {
 	msg.WriteEndOfMessageHeader(client)
 }
 
-func (controller *IdentityTeapot) GetTea(client io.Writer) {
+func (teapot *IdentityTeapot) getTea(client io.Writer) {
 	msg.WriteStatusLine(client, 200, "OK")
 	msg.WriteContentLengthHeader(client, 0)
 	msg.WriteEndOfMessageHeader(client)

--- a/teapot/requests.go
+++ b/teapot/requests.go
@@ -14,14 +14,13 @@ func (teapot *IdentityTeapot) Name() string {
 }
 
 func (teapot *IdentityTeapot) Get(client io.Writer, target string) {
-	switch target {
-	case "/coffee":
-		teapot.getCoffee(client)
-	case "/tea":
-		teapot.getTea(client)
-	default:
-		panic("unknown target") //TODO KDK: Respond?
+	var beverageRequestHandlers = map[string]func(writer io.Writer) {
+		"/coffee": teapot.getCoffee,
+		"/tea": teapot.getTea,
 	}
+
+	handler := beverageRequestHandlers[target]
+	handler(client)
 }
 
 func (teapot *IdentityTeapot) getCoffee(client io.Writer) {

--- a/teapot/requests.go
+++ b/teapot/requests.go
@@ -13,10 +13,19 @@ func (teapot *IdentityTeapot) Name() string {
 	return "teapot"
 }
 
+func (teapot *IdentityTeapot) RespondsTo(target string) bool {
+	switch target {
+	case "/coffee", "/tea":
+		return true
+	default:
+		return false
+	}
+}
+
 func (teapot *IdentityTeapot) Get(client io.Writer, target string) {
-	var beverageRequestHandlers = map[string]func(writer io.Writer) {
+	var beverageRequestHandlers = map[string]func(writer io.Writer){
 		"/coffee": teapot.getCoffee,
-		"/tea": teapot.getTea,
+		"/tea":    teapot.getTea,
 	}
 
 	handler := beverageRequestHandlers[target]

--- a/teapot/requests.go
+++ b/teapot/requests.go
@@ -7,7 +7,7 @@ import (
 )
 
 type GetCoffeeRequest struct {
-	Controller Controller
+	Controller Teapot
 }
 
 func (request *GetCoffeeRequest) Handle(client io.Writer) error {
@@ -16,7 +16,7 @@ func (request *GetCoffeeRequest) Handle(client io.Writer) error {
 }
 
 type GetTeaRequest struct {
-	Controller Controller
+	Controller Teapot
 }
 
 func (request *GetTeaRequest) Handle(client io.Writer) error {
@@ -25,9 +25,24 @@ func (request *GetTeaRequest) Handle(client io.Writer) error {
 }
 
 // Responds as a teapot that is aware of its own identity
-type IdentityController struct{}
+type IdentityTeapot struct{}
 
-func (controller *IdentityController) GetCoffee(client io.Writer) {
+func (controller *IdentityTeapot) Name() string {
+	return "teapot"
+}
+
+func (controller *IdentityTeapot) Get(client io.Writer, target string) {
+	switch target {
+	case "/coffee":
+		controller.GetCoffee(client)
+	case "/tea":
+		controller.GetTea(client)
+	default:
+		panic("unknown target")
+	}
+}
+
+func (controller *IdentityTeapot) GetCoffee(client io.Writer) {
 	body := "I'm a teapot"
 	writeHeaders(client, body)
 	msg.WriteBody(client, body)
@@ -40,7 +55,7 @@ func writeHeaders(client io.Writer, body string) {
 	msg.WriteEndOfMessageHeader(client)
 }
 
-func (controller *IdentityController) GetTea(client io.Writer) {
+func (controller *IdentityTeapot) GetTea(client io.Writer) {
 	msg.WriteStatusLine(client, 200, "OK")
 	msg.WriteContentLengthHeader(client, 0)
 	msg.WriteEndOfMessageHeader(client)

--- a/teapot/requests_test.go
+++ b/teapot/requests_test.go
@@ -15,53 +15,55 @@ var _ = Describe("IdentityTeapot", func() {
 		response       *httptest.ResponseMessage
 		responseBuffer *bytes.Buffer
 	)
+	
+	Describe("#Get", func() {
+		Context("when the target is /coffee", func() {
+			BeforeEach(func() {
+				responseBuffer = &bytes.Buffer{}
+				controller = &teapot.IdentityTeapot{}
 
-	Describe("#GetCoffee", func() {
-		BeforeEach(func() {
-			responseBuffer = &bytes.Buffer{}
-			controller = &teapot.IdentityTeapot{}
+				controller.Get(responseBuffer, "/coffee")
+				response = httptest.ParseResponse(responseBuffer)
+			})
 
-			controller.Get(responseBuffer, "/coffee")
-			response = httptest.ParseResponse(responseBuffer)
-		})
-
-		It("writes a valid HTTP response", func() {
-			response.ShouldBeWellFormed()
-		})
-		It("sets status to 418 I'm a teapot", func() {
-			response.StatusShouldBe(418, "I'm a teapot")
-		})
-		It("sets Content-Length to the length of the body", func() {
-			response.HeaderShould("Content-Length", Equal("12"))
-		})
-		It("sets Content-Type to text/plain", func() {
-			response.HeaderShould("Content-Type", HavePrefix("text/plain"))
-		})
-		It("writes I'm a teapot to the body", func() {
-			response.BodyShould(Equal("I'm a teapot"))
-		})
-	})
-
-	Describe("#GetTea", func() {
-		BeforeEach(func() {
-			responseBuffer = &bytes.Buffer{}
-			controller = &teapot.IdentityTeapot{}
-
-			controller.Get(responseBuffer, "/tea")
-			response = httptest.ParseResponse(responseBuffer)
+			It("writes a valid HTTP response", func() {
+				response.ShouldBeWellFormed()
+			})
+			It("sets status to 418 I'm a teapot", func() {
+				response.StatusShouldBe(418, "I'm a teapot")
+			})
+			It("sets Content-Length to the length of the body", func() {
+				response.HeaderShould("Content-Length", Equal("12"))
+			})
+			It("sets Content-Type to text/plain", func() {
+				response.HeaderShould("Content-Type", HavePrefix("text/plain"))
+			})
+			It("writes I'm a teapot to the body", func() {
+				response.BodyShould(Equal("I'm a teapot"))
+			})
 		})
 
-		It("writes a valid HTTP response", func() {
-			response.ShouldBeWellFormed()
-		})
-		It("sets status to 200 OK", func() {
-			response.StatusShouldBe(200, "OK")
-		})
-		It("sets Content-Length to the length of the body", func() {
-			response.HeaderShould("Content-Length", Equal("0"))
-		})
-		It("has no body", func() {
-			response.BodyShould(BeEmpty())
+		Context("when the target is /tea", func() {
+			BeforeEach(func() {
+				responseBuffer = &bytes.Buffer{}
+				controller = &teapot.IdentityTeapot{}
+
+				controller.Get(responseBuffer, "/tea")
+				response = httptest.ParseResponse(responseBuffer)
+			})
+
+			It("writes a valid HTTP response", func() {
+				response.ShouldBeWellFormed()
+			})
+			It("sets status to 200 OK", func() {
+				response.StatusShouldBe(200, "OK")
+			})
+			It("sets Content-Length to the length of the body", func() {
+				response.HeaderShould("Content-Length", Equal("0"))
+			})
+			It("has no body", func() {
+				response.BodyShould(BeEmpty())
+			})
 		})
 	})
 })

--- a/teapot/requests_test.go
+++ b/teapot/requests_test.go
@@ -11,20 +11,20 @@ import (
 
 var _ = Describe("IdentityTeapot", func() {
 	var (
-		controller     teapot.Teapot
+		theTeapot      teapot.Teapot
 		response       *httptest.ResponseMessage
 		responseBuffer *bytes.Buffer
 	)
 
 	Describe("#RespondsTo", func() {
 		It("returns true for /coffee", func() {
-			controller = &teapot.IdentityTeapot{}
-			Expect(controller.RespondsTo("/coffee")).To(BeTrue())
+			theTeapot = &teapot.IdentityTeapot{}
+			Expect(theTeapot.RespondsTo("/coffee")).To(BeTrue())
 		})
 
 		It("returns true for /tea", func() {
-			controller = &teapot.IdentityTeapot{}
-			Expect(controller.RespondsTo("/tea")).To(BeTrue())
+			theTeapot = &teapot.IdentityTeapot{}
+			Expect(theTeapot.RespondsTo("/tea")).To(BeTrue())
 		})
 	})
 
@@ -32,9 +32,9 @@ var _ = Describe("IdentityTeapot", func() {
 		Context("when the target is /coffee", func() {
 			BeforeEach(func() {
 				responseBuffer = &bytes.Buffer{}
-				controller = &teapot.IdentityTeapot{}
+				theTeapot = &teapot.IdentityTeapot{}
 
-				controller.Get(responseBuffer, "/coffee")
+				theTeapot.Get(responseBuffer, "/coffee")
 				response = httptest.ParseResponse(responseBuffer)
 			})
 
@@ -58,9 +58,9 @@ var _ = Describe("IdentityTeapot", func() {
 		Context("when the target is /tea", func() {
 			BeforeEach(func() {
 				responseBuffer = &bytes.Buffer{}
-				controller = &teapot.IdentityTeapot{}
+				theTeapot = &teapot.IdentityTeapot{}
 
-				controller.Get(responseBuffer, "/tea")
+				theTeapot.Get(responseBuffer, "/tea")
 				response = httptest.ParseResponse(responseBuffer)
 			})
 

--- a/teapot/requests_test.go
+++ b/teapot/requests_test.go
@@ -9,9 +9,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("IdentityController", func() {
+var _ = Describe("IdentityTeapot", func() {
 	var (
-		controller     teapot.Controller
+		controller     teapot.Teapot
 		response       *httptest.ResponseMessage
 		responseBuffer *bytes.Buffer
 	)
@@ -19,7 +19,7 @@ var _ = Describe("IdentityController", func() {
 	Describe("#GetCoffee", func() {
 		BeforeEach(func() {
 			responseBuffer = &bytes.Buffer{}
-			controller = &teapot.IdentityController{}
+			controller = &teapot.IdentityTeapot{}
 
 			controller.GetCoffee(responseBuffer)
 			response = httptest.ParseResponse(responseBuffer)
@@ -45,7 +45,7 @@ var _ = Describe("IdentityController", func() {
 	Describe("#GetTea", func() {
 		BeforeEach(func() {
 			responseBuffer = &bytes.Buffer{}
-			controller = &teapot.IdentityController{}
+			controller = &teapot.IdentityTeapot{}
 
 			controller.GetTea(responseBuffer)
 			response = httptest.ParseResponse(responseBuffer)

--- a/teapot/requests_test.go
+++ b/teapot/requests_test.go
@@ -16,6 +16,18 @@ var _ = Describe("IdentityTeapot", func() {
 		responseBuffer *bytes.Buffer
 	)
 
+	Describe("#RespondsTo", func() {
+		It("returns true for /coffee", func() {
+			controller = &teapot.IdentityTeapot{}
+			Expect(controller.RespondsTo("/coffee")).To(BeTrue())
+		})
+
+		It("returns true for /tea", func() {
+			controller = &teapot.IdentityTeapot{}
+			Expect(controller.RespondsTo("/tea")).To(BeTrue())
+		})
+	})
+
 	Describe("#Get", func() {
 		Context("when the target is /coffee", func() {
 			BeforeEach(func() {

--- a/teapot/requests_test.go
+++ b/teapot/requests_test.go
@@ -15,7 +15,7 @@ var _ = Describe("IdentityTeapot", func() {
 		response       *httptest.ResponseMessage
 		responseBuffer *bytes.Buffer
 	)
-	
+
 	Describe("#Get", func() {
 		Context("when the target is /coffee", func() {
 			BeforeEach(func() {

--- a/teapot/requests_test.go
+++ b/teapot/requests_test.go
@@ -21,7 +21,7 @@ var _ = Describe("IdentityTeapot", func() {
 			responseBuffer = &bytes.Buffer{}
 			controller = &teapot.IdentityTeapot{}
 
-			controller.GetCoffee(responseBuffer)
+			controller.Get(responseBuffer, "/coffee")
 			response = httptest.ParseResponse(responseBuffer)
 		})
 
@@ -47,7 +47,7 @@ var _ = Describe("IdentityTeapot", func() {
 			responseBuffer = &bytes.Buffer{}
 			controller = &teapot.IdentityTeapot{}
 
-			controller.GetTea(responseBuffer)
+			controller.Get(responseBuffer, "/tea")
 			response = httptest.ParseResponse(responseBuffer)
 		})
 

--- a/teapot/route.go
+++ b/teapot/route.go
@@ -8,19 +8,19 @@ import (
 
 func NewRoute() http.Route {
 	teapot := &IdentityTeapot{}
-	return &Route{Resource: teapot}
+	return &Route{Teapot: teapot}
 }
 
 type Route struct {
-	Resource Teapot
+	Teapot Teapot
 }
 
 func (route *Route) Route(requested *http.RequestLine) http.Request {
-	if !route.Resource.RespondsTo(requested.Target) {
+	if !route.Teapot.RespondsTo(requested.Target) {
 		return nil
 	}
 
-	return http.MakeResourceRequest(requested, route.Resource)
+	return http.MakeResourceRequest(requested, route.Teapot)
 }
 
 type Teapot interface {

--- a/teapot/route.go
+++ b/teapot/route.go
@@ -8,18 +8,18 @@ import (
 )
 
 func NewRoute() http.Route {
-	controller := &IdentityController{}
-	return &Route{Controller: controller}
+	controller := &IdentityTeapot{}
+	return &Route{Resource: controller}
 }
 
 type Route struct {
-	Controller Controller
+	Resource Teapot
 }
 
 func (route *Route) Route(requested *http.RequestLine) http.Request {
 	var resources = map[string]http.Request{
-		"/coffee": &GetCoffeeRequest{Controller: route.Controller},
-		"/tea":    &GetTeaRequest{Controller: route.Controller},
+		"/coffee": &GetCoffeeRequest{Controller: route.Resource},
+		"/tea":    &GetTeaRequest{Controller: route.Resource},
 	}
 
 	request, ownResource := resources[requested.Target]
@@ -32,7 +32,9 @@ func (route *Route) Route(requested *http.RequestLine) http.Request {
 	return request
 }
 
-type Controller interface {
+type Teapot interface {
+	Name() string
+	Get(client io.Writer, target string)
 	GetCoffee(client io.Writer)
 	GetTea(client io.Writer)
 }

--- a/teapot/route.go
+++ b/teapot/route.go
@@ -4,12 +4,11 @@ import (
 	"io"
 
 	"github.com/kkrull/gohttp/http"
-	"github.com/kkrull/gohttp/msg/clienterror"
 )
 
 func NewRoute() http.Route {
-	controller := &IdentityTeapot{}
-	return &Route{Resource: controller}
+	teapot := &IdentityTeapot{}
+	return &Route{Resource: teapot}
 }
 
 type Route struct {
@@ -17,24 +16,20 @@ type Route struct {
 }
 
 func (route *Route) Route(requested *http.RequestLine) http.Request {
-	var resources = map[string]http.Request{
-		"/coffee": &GetCoffeeRequest{Controller: route.Resource},
-		"/tea":    &GetTeaRequest{Controller: route.Resource},
+	var resources = map[string]bool{
+		"/coffee": true,
+		"/tea":    true,
 	}
 
-	request, ownResource := resources[requested.Target]
+	_, ownResource := resources[requested.Target]
 	if !ownResource {
 		return nil
-	} else if requested.Method != "GET" {
-		return clienterror.MethodNotAllowed("GET")
 	}
 
-	return request
+	return http.MakeResourceRequest(requested, route.Resource)
 }
 
 type Teapot interface {
 	Name() string
 	Get(client io.Writer, target string)
-	GetCoffee(client io.Writer)
-	GetTea(client io.Writer)
 }

--- a/teapot/route.go
+++ b/teapot/route.go
@@ -17,22 +17,19 @@ type Route struct {
 }
 
 func (route *Route) Route(requested *http.RequestLine) http.Request {
-	if requested.Method != "GET" {
+	var resources = map[string]http.Request{
+		"/coffee": &GetCoffeeRequest{Controller: route.Controller},
+		"/tea":    &GetTeaRequest{Controller: route.Controller},
+	}
+
+	request, ownResource := resources[requested.Target]
+	if !ownResource {
+		return nil
+	} else if requested.Method != "GET" {
 		return clienterror.MethodNotAllowed("GET")
 	}
 
-	switch requested.Target {
-	case "/coffee":
-		return &GetCoffeeRequest{
-			Controller: route.Controller,
-		}
-	case "/tea":
-		return &GetTeaRequest{
-			Controller: route.Controller,
-		}
-	default:
-		return nil
-	}
+	return request
 }
 
 type Controller interface {

--- a/teapot/route.go
+++ b/teapot/route.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/msg/clienterror"
 )
 
 func NewRoute() http.Route {
@@ -17,7 +18,7 @@ type Route struct {
 
 func (route *Route) Route(requested *http.RequestLine) http.Request {
 	if requested.Method != "GET" {
-		return nil
+		return clienterror.MethodNotAllowed("GET")
 	}
 
 	switch requested.Target {

--- a/teapot/route.go
+++ b/teapot/route.go
@@ -16,13 +16,7 @@ type Route struct {
 }
 
 func (route *Route) Route(requested *http.RequestLine) http.Request {
-	var resources = map[string]bool{
-		"/coffee": true,
-		"/tea":    true,
-	}
-
-	_, ownResource := resources[requested.Target]
-	if !ownResource {
+	if !route.Resource.RespondsTo(requested.Target) {
 		return nil
 	}
 
@@ -32,4 +26,5 @@ func (route *Route) Route(requested *http.RequestLine) http.Request {
 type Teapot interface {
 	Name() string
 	Get(client io.Writer, target string)
+	RespondsTo(target string) bool
 }

--- a/teapot/route_test.go
+++ b/teapot/route_test.go
@@ -18,43 +18,31 @@ var _ = Describe("teapotRoute", func() {
 		routedRequest http.Request
 	)
 
-	BeforeEach(func() {
-		controller = &TeapotMock{}
-		router = &teapot.Route{Resource: controller}
-	})
-
 	Describe("#Route", func() {
-		Context("when the target is /coffee", func() {
-			It("routes GET /coffee to Resource#Get", func() {
-				requested = &http.RequestLine{Method: "GET", Target: "/coffee"}
+		Context("when the target is a resource that the teapot can respond to", func() {
+			BeforeEach(func() {
+				controller = &TeapotMock{RespondsToTarget: "/caffeine"}
+				router = &teapot.Route{Resource: controller}
+			})
+
+			It("routes GET requests to that target to the teapot", func() {
+				requested = &http.RequestLine{Method: "GET", Target: "/caffeine"}
 				routedRequest = router.Route(requested)
 				routedRequest.Handle(&bufio.Writer{})
-				controller.GetShouldHaveReceived("/coffee")
+				controller.GetShouldHaveReceived("/caffeine")
 			})
 
 			It("returns MethodNotAllowed for any other method", func() {
-				requested := &http.RequestLine{Method: "TRACE", Target: "/coffee"}
-				routedRequest := router.Route(requested)
-				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET", "OPTIONS")))
-			})
-		})
-
-		Context("when the target is /tea", func() {
-			It("routes GET /tea to Resource#Get", func() {
-				requested = &http.RequestLine{Method: "GET", Target: "/tea"}
-				routedRequest = router.Route(requested)
-				routedRequest.Handle(&bufio.Writer{})
-				controller.GetShouldHaveReceived("/tea")
-			})
-
-			It("returns MethodNotAllowed for any other method", func() {
-				requested := &http.RequestLine{Method: "TRACE", Target: "/tea"}
+				requested := &http.RequestLine{Method: "TRACE", Target: "/caffeine"}
 				routedRequest := router.Route(requested)
 				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET", "OPTIONS")))
 			})
 		})
 
 		It("passes on any other target", func() {
+			controller = &TeapotMock{}
+			router = &teapot.Route{Resource: controller}
+
 			requested = &http.RequestLine{Method: "GET", Target: "/file.txt"}
 			routedRequest = router.Route(requested)
 			Expect(routedRequest).To(BeNil())

--- a/teapot/route_test.go
+++ b/teapot/route_test.go
@@ -13,19 +13,19 @@ import (
 var _ = Describe("teapotRoute", func() {
 	var (
 		router        http.Route
-		controller    *ControllerMock
+		controller    *TeapotMock
 		requested     *http.RequestLine
 		routedRequest http.Request
 	)
 
 	BeforeEach(func() {
-		controller = &ControllerMock{}
-		router = &teapot.Route{Controller: controller}
+		controller = &TeapotMock{}
+		router = &teapot.Route{Resource: controller}
 	})
 
 	Describe("#Route", func() {
 		Context("when the target is /coffee", func() {
-			It("routes GET /coffee to Controller#GetCoffee", func() {
+			It("routes GET /coffee to Resource#GetCoffee", func() {
 				requested = &http.RequestLine{Method: "GET", Target: "/coffee"}
 				routedRequest = router.Route(requested)
 				routedRequest.Handle(&bufio.Writer{})
@@ -40,7 +40,7 @@ var _ = Describe("teapotRoute", func() {
 		})
 
 		Context("when the target is /tea", func() {
-			It("routes GET /tea to Controller#GetCoffee", func() {
+			It("routes GET /tea to Resource#GetCoffee", func() {
 				requested = &http.RequestLine{Method: "GET", Target: "/tea"}
 				routedRequest = router.Route(requested)
 				routedRequest.Handle(&bufio.Writer{})

--- a/teapot/route_test.go
+++ b/teapot/route_test.go
@@ -25,7 +25,7 @@ var _ = Describe("teapotRoute", func() {
 
 	Describe("#Route", func() {
 		Context("when the target is /coffee", func() {
-			It("routes GET /coffee to Resource#GetCoffee", func() {
+			It("routes GET /coffee to Resource#Get", func() {
 				requested = &http.RequestLine{Method: "GET", Target: "/coffee"}
 				routedRequest = router.Route(requested)
 				routedRequest.Handle(&bufio.Writer{})
@@ -40,7 +40,7 @@ var _ = Describe("teapotRoute", func() {
 		})
 
 		Context("when the target is /tea", func() {
-			It("routes GET /tea to Resource#GetCoffee", func() {
+			It("routes GET /tea to Resource#Get", func() {
 				requested = &http.RequestLine{Method: "GET", Target: "/tea"}
 				routedRequest = router.Route(requested)
 				routedRequest.Handle(&bufio.Writer{})

--- a/teapot/route_test.go
+++ b/teapot/route_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/msg/clienterror"
 	"github.com/kkrull/gohttp/teapot"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,24 +24,34 @@ var _ = Describe("teapotRoute", func() {
 	})
 
 	Describe("#Route", func() {
-		It("routes GET /coffee to Controller#GetCoffee", func() {
-			requested = &http.RequestLine{Method: "GET", Target: "/coffee"}
-			routedRequest = router.Route(requested)
-			routedRequest.Handle(&bufio.Writer{})
-			controller.GetCoffeeShouldHaveBeenCalled()
+		Context("when the target is /coffee", func() {
+			It("routes GET /coffee to Controller#GetCoffee", func() {
+				requested = &http.RequestLine{Method: "GET", Target: "/coffee"}
+				routedRequest = router.Route(requested)
+				routedRequest.Handle(&bufio.Writer{})
+				controller.GetCoffeeShouldHaveBeenCalled()
+			})
+
+			It("returns MethodNotAllowed for any other method", func() {
+				requested := &http.RequestLine{Method: "TRACE", Target: "/coffee"}
+				routedRequest := router.Route(requested)
+				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET")))
+			})
 		})
 
-		It("routes GET /tea to Controller#GetCoffee", func() {
-			requested = &http.RequestLine{Method: "GET", Target: "/tea"}
-			routedRequest = router.Route(requested)
-			routedRequest.Handle(&bufio.Writer{})
-			controller.GetTeaShouldHaveBeenCalled()
-		})
+		Context("when the target is /tea", func() {
+			It("routes GET /tea to Controller#GetCoffee", func() {
+				requested = &http.RequestLine{Method: "GET", Target: "/tea"}
+				routedRequest = router.Route(requested)
+				routedRequest.Handle(&bufio.Writer{})
+				controller.GetTeaShouldHaveBeenCalled()
+			})
 
-		It("passes on any other method", func() {
-			requested = &http.RequestLine{Method: "OPTIONS", Target: "/tea"}
-			routedRequest = router.Route(requested)
-			Expect(routedRequest).To(BeNil())
+			It("returns MethodNotAllowed for any other method", func() {
+				requested := &http.RequestLine{Method: "TRACE", Target: "/tea"}
+				routedRequest := router.Route(requested)
+				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET")))
+			})
 		})
 
 		It("passes on any other target", func() {

--- a/teapot/route_test.go
+++ b/teapot/route_test.go
@@ -29,13 +29,13 @@ var _ = Describe("teapotRoute", func() {
 				requested = &http.RequestLine{Method: "GET", Target: "/coffee"}
 				routedRequest = router.Route(requested)
 				routedRequest.Handle(&bufio.Writer{})
-				controller.GetCoffeeShouldHaveBeenCalled()
+				controller.GetShouldHaveReceived("/coffee")
 			})
 
 			It("returns MethodNotAllowed for any other method", func() {
 				requested := &http.RequestLine{Method: "TRACE", Target: "/coffee"}
 				routedRequest := router.Route(requested)
-				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET")))
+				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET", "OPTIONS")))
 			})
 		})
 
@@ -44,13 +44,13 @@ var _ = Describe("teapotRoute", func() {
 				requested = &http.RequestLine{Method: "GET", Target: "/tea"}
 				routedRequest = router.Route(requested)
 				routedRequest.Handle(&bufio.Writer{})
-				controller.GetTeaShouldHaveBeenCalled()
+				controller.GetShouldHaveReceived("/tea")
 			})
 
 			It("returns MethodNotAllowed for any other method", func() {
 				requested := &http.RequestLine{Method: "TRACE", Target: "/tea"}
 				routedRequest := router.Route(requested)
-				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET")))
+				Expect(routedRequest).To(BeEquivalentTo(clienterror.MethodNotAllowed("GET", "OPTIONS")))
 			})
 		})
 

--- a/teapot/route_test.go
+++ b/teapot/route_test.go
@@ -13,7 +13,7 @@ import (
 var _ = Describe("teapotRoute", func() {
 	var (
 		router        http.Route
-		controller    *TeapotMock
+		teapotMock    *TeapotMock
 		requested     *http.RequestLine
 		routedRequest http.Request
 	)
@@ -21,15 +21,15 @@ var _ = Describe("teapotRoute", func() {
 	Describe("#Route", func() {
 		Context("when the target is a resource that the teapot can respond to", func() {
 			BeforeEach(func() {
-				controller = &TeapotMock{RespondsToTarget: "/caffeine"}
-				router = &teapot.Route{Resource: controller}
+				teapotMock = &TeapotMock{RespondsToTarget: "/caffeine"}
+				router = &teapot.Route{Teapot: teapotMock}
 			})
 
 			It("routes GET requests to that target to the teapot", func() {
 				requested = &http.RequestLine{Method: "GET", Target: "/caffeine"}
 				routedRequest = router.Route(requested)
 				routedRequest.Handle(&bufio.Writer{})
-				controller.GetShouldHaveReceived("/caffeine")
+				teapotMock.GetShouldHaveReceived("/caffeine")
 			})
 
 			It("returns MethodNotAllowed for any other method", func() {
@@ -40,8 +40,8 @@ var _ = Describe("teapotRoute", func() {
 		})
 
 		It("passes on any other target", func() {
-			controller = &TeapotMock{}
-			router = &teapot.Route{Resource: controller}
+			teapotMock = &TeapotMock{}
+			router = &teapot.Route{Teapot: teapotMock}
 
 			requested = &http.RequestLine{Method: "GET", Target: "/file.txt"}
 			routedRequest = router.Route(requested)

--- a/teapot/teapot_suite_test.go
+++ b/teapot/teapot_suite_test.go
@@ -14,6 +14,7 @@ func TestTeapot(t *testing.T) {
 }
 
 type TeapotMock struct {
+	getTarget string
 	getCoffeeCalled bool
 	getTeaCalled    bool
 }
@@ -23,21 +24,9 @@ func (mock *TeapotMock) Name() string {
 }
 
 func (mock *TeapotMock) Get(client io.Writer, target string) {
-	panic("implement me")
+	mock.getTarget = target
 }
 
-func (mock *TeapotMock) GetCoffee(client io.Writer) {
-	mock.getCoffeeCalled = true
-}
-
-func (mock *TeapotMock) GetCoffeeShouldHaveBeenCalled() {
-	ExpectWithOffset(1, mock.getCoffeeCalled).To(BeTrue())
-}
-
-func (mock *TeapotMock) GetTea(client io.Writer) {
-	mock.getTeaCalled = true
-}
-
-func (mock *TeapotMock) GetTeaShouldHaveBeenCalled() {
-	ExpectWithOffset(1, mock.getTeaCalled).To(BeTrue())
+func (mock *TeapotMock) GetShouldHaveReceived(target string) {
+	ExpectWithOffset(1, mock.getTarget).To(Equal(target))
 }

--- a/teapot/teapot_suite_test.go
+++ b/teapot/teapot_suite_test.go
@@ -14,11 +14,16 @@ func TestTeapot(t *testing.T) {
 }
 
 type TeapotMock struct {
-	getTarget       string
+	RespondsToTarget string
+	getTarget        string
 }
 
 func (mock *TeapotMock) Name() string {
 	return "teapot mock"
+}
+
+func (mock *TeapotMock) RespondsTo(target string) bool {
+	return mock.RespondsToTarget == target
 }
 
 func (mock *TeapotMock) Get(client io.Writer, target string) {

--- a/teapot/teapot_suite_test.go
+++ b/teapot/teapot_suite_test.go
@@ -13,23 +13,31 @@ func TestTeapot(t *testing.T) {
 	RunSpecs(t, "teapot")
 }
 
-type ControllerMock struct {
+type TeapotMock struct {
 	getCoffeeCalled bool
 	getTeaCalled    bool
 }
 
-func (mock *ControllerMock) GetCoffee(client io.Writer) {
+func (mock *TeapotMock) Name() string {
+	return "teapot mock"
+}
+
+func (mock *TeapotMock) Get(client io.Writer, target string) {
+	panic("implement me")
+}
+
+func (mock *TeapotMock) GetCoffee(client io.Writer) {
 	mock.getCoffeeCalled = true
 }
 
-func (mock *ControllerMock) GetCoffeeShouldHaveBeenCalled() {
+func (mock *TeapotMock) GetCoffeeShouldHaveBeenCalled() {
 	ExpectWithOffset(1, mock.getCoffeeCalled).To(BeTrue())
 }
 
-func (mock *ControllerMock) GetTea(client io.Writer) {
+func (mock *TeapotMock) GetTea(client io.Writer) {
 	mock.getTeaCalled = true
 }
 
-func (mock *ControllerMock) GetTeaShouldHaveBeenCalled() {
+func (mock *TeapotMock) GetTeaShouldHaveBeenCalled() {
 	ExpectWithOffset(1, mock.getTeaCalled).To(BeTrue())
 }

--- a/teapot/teapot_suite_test.go
+++ b/teapot/teapot_suite_test.go
@@ -15,8 +15,6 @@ func TestTeapot(t *testing.T) {
 
 type TeapotMock struct {
 	getTarget       string
-	getCoffeeCalled bool
-	getTeaCalled    bool
 }
 
 func (mock *TeapotMock) Name() string {

--- a/teapot/teapot_suite_test.go
+++ b/teapot/teapot_suite_test.go
@@ -14,7 +14,7 @@ func TestTeapot(t *testing.T) {
 }
 
 type TeapotMock struct {
-	getTarget string
+	getTarget       string
 	getCoffeeCalled bool
 	getTeaCalled    bool
 }


### PR DESCRIPTION
Now all the routes in each of the packages

- implement the `Resource` interface, with extensions such as `GetResource`, `HeadResource`, etc...
- Implement OPTIONS requests in a standardized manner, using `http.MakeResourceRequest`
- Implement Method Not Found in a standardized manner, using `http.MakeResourceRequest`