### PR TITLE
SimplePost / SimplePut

### DIFF
--- a/http/logging.go
+++ b/http/logging.go
@@ -23,4 +23,6 @@ func (logger TextLogger) Parsed(message RequestMessage) {
 	for _, header := range message.HeaderLines() {
 		fmt.Fprintln(logger.Writer, header)
 	}
+	fmt.Fprintln(logger.Writer)
+	fmt.Fprintf(logger.Writer, "%s", message.Body())
 }

--- a/http/messages.go
+++ b/http/messages.go
@@ -74,6 +74,7 @@ type requestMessage struct {
 	target          string
 	queryParameters []QueryParameter
 	headers         []header
+	body            []byte
 }
 
 func (message *requestMessage) Method() string {
@@ -124,6 +125,14 @@ func (message *requestMessage) HeaderValues(field string) []string {
 
 func (message *requestMessage) AddHeader(field, value string) {
 	message.headers = append(message.headers, header{Field: field, Value: value})
+}
+
+func (message *requestMessage) Body() []byte {
+	return message.body
+}
+
+func (message *requestMessage) SetBody(body []byte) {
+	message.body = body
 }
 
 func (message *requestMessage) NotImplemented() Response {

--- a/http/messages.go
+++ b/http/messages.go
@@ -44,6 +44,14 @@ func NewOptionsMessage(targetAsteriskOrPath string) RequestMessage {
 	}
 }
 
+func NewPostMessage(path string) RequestMessage {
+	return &requestMessage{
+		method: POST,
+		target: path,
+		path:   path,
+	}
+}
+
 func NewPutMessage(path string) RequestMessage {
 	return &requestMessage{
 		method: PUT,

--- a/http/methods.go
+++ b/http/methods.go
@@ -12,11 +12,11 @@ import (
 
 type getMethod struct{}
 
-func (method *getMethod) MakeRequest(requested *requestMessage, resource Resource) (request Request, isSupported bool) {
+func (method *getMethod) MakeRequest(message *requestMessage, resource Resource) (request Request, isSupported bool) {
 	supportedResource, ok := resource.(GetResource)
 	if ok {
 		return &getRequest{
-			Message:  requested,
+			Message:  message,
 			Resource: supportedResource,
 		}, true
 	}
@@ -86,12 +86,12 @@ func (request *optionsRequest) Handle(client io.Writer) error {
 
 type postMethod struct{}
 
-func (*postMethod) MakeRequest(requested *requestMessage, resource Resource) (request Request, isSupported bool) {
+func (*postMethod) MakeRequest(message *requestMessage, resource Resource) (request Request, isSupported bool) {
 	supportedResource, ok := resource.(PostResource)
 	if ok {
 		return &postRequest{
+			Message:  message,
 			Resource: supportedResource,
-			Target:   requested.target,
 		}, true
 	}
 
@@ -99,29 +99,29 @@ func (*postMethod) MakeRequest(requested *requestMessage, resource Resource) (re
 }
 
 type postRequest struct {
+	Message  RequestMessage
 	Resource PostResource
-	Target   string
 }
 
 func (request *postRequest) Handle(client io.Writer) error {
-	request.Resource.Post(client, request.Target)
+	request.Resource.Post(client, request.Message)
 	return nil
 }
 
 type PostResource interface {
-	Post(client io.Writer, target string)
+	Post(client io.Writer, message RequestMessage)
 }
 
 /* PUT */
 
 type putMethod struct{}
 
-func (*putMethod) MakeRequest(requested *requestMessage, resource Resource) (request Request, isSupported bool) {
+func (*putMethod) MakeRequest(message *requestMessage, resource Resource) (request Request, isSupported bool) {
 	supportedResource, ok := resource.(PutResource)
 	if ok {
 		return &putRequest{
+			Message:  message,
 			Resource: supportedResource,
-			Target:   requested.target,
 		}, true
 	}
 
@@ -129,15 +129,15 @@ func (*putMethod) MakeRequest(requested *requestMessage, resource Resource) (req
 }
 
 type putRequest struct {
+	Message  RequestMessage
 	Resource PutResource
-	Target   string
 }
 
 func (request *putRequest) Handle(client io.Writer) error {
-	request.Resource.Put(client, request.Target)
+	request.Resource.Put(client, request.Message)
 	return nil
 }
 
 type PutResource interface {
-	Put(client io.Writer, target string)
+	Put(client io.Writer, message RequestMessage)
 }

--- a/http/parser_test.go
+++ b/http/parser_test.go
@@ -88,6 +88,37 @@ var _ = Describe("LineRequestParser", func() {
 			})
 		})
 
+		Context("given a request with a Content-Length header", func() {
+			var reader *bufio.Reader
+
+			BeforeEach(func() {
+				buffer := bytes.NewBufferString("POST /foo HTTP/1.1\r\nContent-Length: 4\r\n\r\nABCD")
+				reader = bufio.NewReader(buffer)
+				request, err = parser.Parse(reader)
+			})
+
+			It("parses the request-line", func() {
+				Expect(request.Method()).To(Equal(http.POST))
+				Expect(request.Target()).To(Equal("/foo"))
+			})
+
+			It("parses the headers", func() {
+				Expect(request.HeaderValues("Content-Length")).To(Equal([]string{"4"}))
+			})
+
+			It("parses the body", func() {
+				Expect(request.Body()).To(Equal([]byte{65, 66, 67, 68}))
+			})
+
+			It("returns no error", func() {
+				Expect(err).To(BeNil())
+			})
+
+			It("reads the whole request", func() {
+				Expect(reader.Buffered()).To(Equal(0))
+			})
+		})
+
 		Context("given a target with no query or fragment", func() {
 			BeforeEach(func() {
 				request, _ = parser.Parse(requestWithTarget("/widget"))

--- a/http/router.go
+++ b/http/router.go
@@ -66,10 +66,12 @@ type RequestMessage interface {
 	Target() string
 	Path() string
 	QueryParameters() []QueryParameter
+
 	HeaderLines() []string
+	HeaderValues(field string) (values []string)
+	Body() []byte
 
 	MakeResourceRequest(resource Resource) Request
-	HeaderValues(field string) (values []string)
 }
 
 type Route interface {

--- a/httptest/request_message.go
+++ b/httptest/request_message.go
@@ -18,6 +18,7 @@ type RequestMessage struct {
 
 	queryParameters []http.QueryParameter
 	headers         []header
+	body            []byte
 }
 
 func (message *RequestMessage) Method() string {
@@ -60,6 +61,10 @@ func (message *RequestMessage) HeaderValues(field string) (values []string) {
 	}
 
 	return values
+}
+
+func (message *RequestMessage) Body() []byte {
+	return message.body
 }
 
 func (message *RequestMessage) MakeResourceRequest(resource http.Resource) http.Request {

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -47,7 +47,7 @@ func (factory *InterruptFactory) TCPServer(contentRootPath string, host string, 
 func (factory *InterruptFactory) routerWithAllRoutes(contentRootPath string) http.Router {
 	router := http.NewRouter()
 	router.AddRoute(capability.NewRoute())
-	router.AddRoute(playground.NewFormRoute())
+	router.AddRoute(playground.NewFormRoute("/form"))
 	router.AddRoute(playground.NewParameterRoute())
 	router.AddRoute(playground.NewReadOnlyRoute())
 	router.AddRoute(playground.NewReadWriteRoute())

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -47,6 +47,7 @@ func (factory *InterruptFactory) TCPServer(contentRootPath string, host string, 
 func (factory *InterruptFactory) routerWithAllRoutes(contentRootPath string) http.Router {
 	router := http.NewRouter()
 	router.AddRoute(capability.NewRoute())
+	router.AddRoute(playground.NewFormRoute())
 	router.AddRoute(playground.NewParameterRoute())
 	router.AddRoute(playground.NewReadOnlyRoute())
 	router.AddRoute(playground.NewReadWriteRoute())

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -48,6 +48,7 @@ func (factory *InterruptFactory) routerWithAllRoutes(contentRootPath string) htt
 	router := http.NewRouter()
 	router.AddRoute(capability.NewRoute())
 	router.AddRoute(playground.NewFormRoute("/form"))
+	router.AddRoute(playground.NewFormRoute("/put-target"))
 	router.AddRoute(playground.NewParameterRoute())
 	router.AddRoute(playground.NewReadOnlyRoute())
 	router.AddRoute(playground.NewReadWriteRoute())

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -91,6 +91,10 @@ var _ = Describe("InterruptFactory", func() {
 			Expect(typedServer.Routes()).To(ContainElement(BeAssignableToTypeOf(capability.NewRoute())))
 		})
 
+		It("has a playground route for a form", func() {
+			Expect(typedServer.Routes()).To(ContainElement(BeAssignableToTypeOf(playground.NewFormRoute())))
+		})
+
 		It("has a playground route for parameter decoding", func() {
 			Expect(typedServer.Routes()).To(ContainElement(BeAssignableToTypeOf(playground.NewParameterRoute())))
 		})

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -92,7 +92,11 @@ var _ = Describe("InterruptFactory", func() {
 		})
 
 		It("has a playground route for a form at /form", func() {
-			Expect(typedServer.Routes()).To(ContainElement(BeAssignableToTypeOf(playground.NewFormRoute("/form"))))
+			Expect(typedServer.Routes()).To(ContainElement(BeEquivalentTo(playground.NewFormRoute("/form"))))
+		})
+
+		It("has a playground route for a form at /put-target", func() {
+			Expect(typedServer.Routes()).To(ContainElement(BeEquivalentTo(playground.NewFormRoute("/put-target"))))
 		})
 
 		It("has a playground route for parameter decoding", func() {

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -91,8 +91,8 @@ var _ = Describe("InterruptFactory", func() {
 			Expect(typedServer.Routes()).To(ContainElement(BeAssignableToTypeOf(capability.NewRoute())))
 		})
 
-		It("has a playground route for a form", func() {
-			Expect(typedServer.Routes()).To(ContainElement(BeAssignableToTypeOf(playground.NewFormRoute())))
+		It("has a playground route for a form at /form", func() {
+			Expect(typedServer.Routes()).To(ContainElement(BeAssignableToTypeOf(playground.NewFormRoute("/form"))))
 		})
 
 		It("has a playground route for parameter decoding", func() {

--- a/playground/form_route.go
+++ b/playground/form_route.go
@@ -4,6 +4,8 @@ import (
 	"io"
 
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/msg"
+	"github.com/kkrull/gohttp/msg/success"
 )
 
 func NewFormRoute() *FormRoute {
@@ -30,5 +32,7 @@ func (*SingletonForm) Name() string {
 	return "Singleton form"
 }
 
-func (*SingletonForm) Post(client io.Writer, message http.RequestMessage) {
+func (form *SingletonForm) Post(client io.Writer, message http.RequestMessage) {
+	msg.WriteStatus(client, success.OKStatus)
+	msg.WriteEndOfMessageHeader(client)
 }

--- a/playground/form_route.go
+++ b/playground/form_route.go
@@ -38,3 +38,8 @@ func (form *SingletonForm) Post(client io.Writer, message http.RequestMessage) {
 	msg.WriteStatus(client, success.OKStatus)
 	msg.WriteEndOfMessageHeader(client)
 }
+
+func (form *SingletonForm) Put(client io.Writer, message http.RequestMessage) {
+	msg.WriteStatus(client, success.OKStatus)
+	msg.WriteEndOfMessageHeader(client)
+}

--- a/playground/form_route.go
+++ b/playground/form_route.go
@@ -8,18 +8,20 @@ import (
 	"github.com/kkrull/gohttp/msg/success"
 )
 
-func NewFormRoute() *FormRoute {
+func NewFormRoute(path string) *FormRoute {
 	return &FormRoute{
+		Path: path,
 		Form: &SingletonForm{},
 	}
 }
 
 type FormRoute struct {
+	Path string
 	Form *SingletonForm
 }
 
 func (route *FormRoute) Route(requested http.RequestMessage) http.Request {
-	if requested.Path() != "/form" {
+	if requested.Path() != route.Path {
 		return nil
 	}
 

--- a/playground/form_route.go
+++ b/playground/form_route.go
@@ -1,0 +1,34 @@
+package playground
+
+import (
+	"io"
+
+	"github.com/kkrull/gohttp/http"
+)
+
+func NewFormRoute() *FormRoute {
+	return &FormRoute{
+		Form: &SingletonForm{},
+	}
+}
+
+type FormRoute struct {
+	Form *SingletonForm
+}
+
+func (route *FormRoute) Route(requested http.RequestMessage) http.Request {
+	if requested.Path() != "/form" {
+		return nil
+	}
+
+	return requested.MakeResourceRequest(route.Form)
+}
+
+type SingletonForm struct{}
+
+func (*SingletonForm) Name() string {
+	return "Singleton form"
+}
+
+func (*SingletonForm) Post(client io.Writer, message http.RequestMessage) {
+}

--- a/playground/form_route_test.go
+++ b/playground/form_route_test.go
@@ -1,0 +1,61 @@
+package playground_test
+
+import (
+	"bytes"
+
+	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/httptest"
+	"github.com/kkrull/gohttp/msg/clienterror"
+	"github.com/kkrull/gohttp/playground"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("::NewFormRoute", func() {
+	It("returns a FormRoute", func() {
+		route := playground.NewFormRoute()
+		Expect(route).NotTo(BeNil())
+		Expect(route).To(BeEquivalentTo(&playground.FormRoute{
+			Form: &playground.SingletonForm{},
+		}))
+	})
+})
+
+var _ = Describe("FormRoute", func() {
+	Describe("#Route", func() {
+		var (
+			router   http.Route
+			response = &bytes.Buffer{}
+		)
+
+		BeforeEach(func() {
+			router = &playground.FormRoute{}
+			response.Reset()
+		})
+
+		Context("when the path is /form", func() {
+			Context("when the method is OPTIONS", func() {
+				BeforeEach(func() {
+					requested := http.NewOptionsMessage("/form")
+					routedRequest := router.Route(requested)
+					Expect(routedRequest).NotTo(BeNil())
+					routedRequest.Handle(response)
+				})
+
+				It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
+				It("allows POST", httptest.ShouldAllowMethods(response, http.POST, http.OPTIONS))
+			})
+
+			It("replies Method Not Allowed on any other method", func() {
+				requested := http.NewTraceMessage("/form")
+				routedRequest := router.Route(requested)
+				Expect(routedRequest).To(BeAssignableToTypeOf(clienterror.MethodNotAllowed()))
+			})
+		})
+
+		It("returns nil for any other path", func() {
+			requested := http.NewGetMessage("/")
+			Expect(router.Route(requested)).To(BeNil())
+		})
+	})
+})

--- a/playground/form_route_test.go
+++ b/playground/form_route_test.go
@@ -47,7 +47,9 @@ var _ = Describe("FormRoute", func() {
 				})
 
 				It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
-				It("allows POST", httptest.ShouldAllowMethods(response, http.POST, http.OPTIONS))
+				It("allows OPTIONS", httptest.ShouldAllowMethods(response, http.OPTIONS))
+				It("allows POST", httptest.ShouldAllowMethods(response, http.POST))
+				It("allows PUT", httptest.ShouldAllowMethods(response, http.PUT))
 			})
 
 			It("replies Method Not Allowed on any other method", func() {
@@ -65,19 +67,19 @@ var _ = Describe("FormRoute", func() {
 })
 
 var _ = Describe("SingletonForm", func() {
+	var (
+		form            *playground.SingletonForm
+		request         *httptest.RequestMessage
+		responseMessage *httptest.ResponseMessage
+
+		response = &bytes.Buffer{}
+	)
+
+	BeforeEach(func() {
+		response.Reset()
+	})
+
 	Describe("#Post", func() {
-		var (
-			form            *playground.SingletonForm
-			request         *httptest.RequestMessage
-			responseMessage *httptest.ResponseMessage
-
-			response = &bytes.Buffer{}
-		)
-
-		BeforeEach(func() {
-			response.Reset()
-		})
-
 		Context("given any data in the body", func() {
 			BeforeEach(func() {
 				form = &playground.SingletonForm{}
@@ -87,6 +89,26 @@ var _ = Describe("SingletonForm", func() {
 				}
 
 				form.Post(response, request)
+				responseMessage = httptest.ParseResponse(response)
+			})
+
+			It("responds 200 OK", func() {
+				responseMessage.ShouldBeWellFormed()
+				responseMessage.StatusShouldBe(200, "OK")
+			})
+		})
+	})
+
+	Describe("#Put", func() {
+		Context("given any data in the body", func() {
+			BeforeEach(func() {
+				form = &playground.SingletonForm{}
+				request = &httptest.RequestMessage{
+					MethodReturns: http.PUT,
+					PathReturns:   "/form",
+				}
+
+				form.Put(response, request)
 				responseMessage = httptest.ParseResponse(response)
 			})
 

--- a/playground/form_route_test.go
+++ b/playground/form_route_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 var _ = Describe("::NewFormRoute", func() {
-	It("returns a FormRoute", func() {
-		route := playground.NewFormRoute()
+	It("returns a FormRoute at the given path", func() {
+		route := playground.NewFormRoute("/oracle")
 		Expect(route).NotTo(BeNil())
 		Expect(route).To(BeEquivalentTo(&playground.FormRoute{
+			Path: "/oracle",
 			Form: &playground.SingletonForm{},
 		}))
 	})
@@ -23,20 +24,23 @@ var _ = Describe("::NewFormRoute", func() {
 
 var _ = Describe("FormRoute", func() {
 	Describe("#Route", func() {
+		const givenPath = "/sweetness"
+
 		var (
 			router   http.Route
 			response = &bytes.Buffer{}
 		)
 
 		BeforeEach(func() {
-			router = &playground.FormRoute{}
+			router = &playground.FormRoute{Path: givenPath}
 			response.Reset()
 		})
 
-		Context("when the path is /form", func() {
+		Context("when the path is exactly equal to the given path", func() {
+
 			Context("when the method is OPTIONS", func() {
 				BeforeEach(func() {
-					requested := http.NewOptionsMessage("/form")
+					requested := http.NewOptionsMessage(givenPath)
 					routedRequest := router.Route(requested)
 					Expect(routedRequest).NotTo(BeNil())
 					routedRequest.Handle(response)
@@ -47,7 +51,7 @@ var _ = Describe("FormRoute", func() {
 			})
 
 			It("replies Method Not Allowed on any other method", func() {
-				requested := http.NewTraceMessage("/form")
+				requested := http.NewTraceMessage(givenPath)
 				routedRequest := router.Route(requested)
 				Expect(routedRequest).To(BeAssignableToTypeOf(clienterror.MethodNotAllowed()))
 			})

--- a/playground/form_route_test.go
+++ b/playground/form_route_test.go
@@ -59,3 +59,37 @@ var _ = Describe("FormRoute", func() {
 		})
 	})
 })
+
+var _ = Describe("SingletonForm", func() {
+	Describe("#Post", func() {
+		var (
+			form            *playground.SingletonForm
+			request         *httptest.RequestMessage
+			responseMessage *httptest.ResponseMessage
+
+			response = &bytes.Buffer{}
+		)
+
+		BeforeEach(func() {
+			response.Reset()
+		})
+
+		Context("given any data in the body", func() {
+			BeforeEach(func() {
+				form = &playground.SingletonForm{}
+				request = &httptest.RequestMessage{
+					MethodReturns: http.POST,
+					PathReturns:   "/form",
+				}
+
+				form.Post(response, request)
+				responseMessage = httptest.ParseResponse(response)
+			})
+
+			It("responds 200 OK", func() {
+				responseMessage.ShouldBeWellFormed()
+				responseMessage.StatusShouldBe(200, "OK")
+			})
+		})
+	})
+})

--- a/playground/parameter_route_test.go
+++ b/playground/parameter_route_test.go
@@ -77,7 +77,7 @@ var _ = Describe("ParameterRoute", func() {
 var _ = Describe("AssignmentReporter", func() {
 	Describe("#Get", func() {
 		var (
-			controller      *playground.AssignmentReporter
+			reporter        *playground.AssignmentReporter
 			request         *httptest.RequestMessage
 			responseMessage *httptest.ResponseMessage
 
@@ -90,13 +90,13 @@ var _ = Describe("AssignmentReporter", func() {
 
 		Context("given any number of query parameters", func() {
 			BeforeEach(func() {
-				controller = &playground.AssignmentReporter{}
+				reporter = &playground.AssignmentReporter{}
 				request = &httptest.RequestMessage{
 					MethodReturns: http.GET,
 					PathReturns:   "/parameters",
 				}
 
-				controller.Get(response, request)
+				reporter.Get(response, request)
 				responseMessage = httptest.ParseResponse(response)
 			})
 
@@ -111,13 +111,13 @@ var _ = Describe("AssignmentReporter", func() {
 
 		Context("given a request with no query parameters", func() {
 			BeforeEach(func() {
-				controller = &playground.AssignmentReporter{}
+				reporter = &playground.AssignmentReporter{}
 				request = &httptest.RequestMessage{
 					MethodReturns: http.GET,
 					PathReturns:   "/parameters",
 				}
 
-				controller.Get(response, request)
+				reporter.Get(response, request)
 				responseMessage = httptest.ParseResponse(response)
 			})
 
@@ -131,14 +131,14 @@ var _ = Describe("AssignmentReporter", func() {
 
 		Context("given a request with 1 or more query parameters", func() {
 			BeforeEach(func() {
-				controller = &playground.AssignmentReporter{}
+				reporter = &playground.AssignmentReporter{}
 				request = &httptest.RequestMessage{
 					MethodReturns: http.GET,
 					PathReturns:   "/parameters",
 				}
 				request.AddQueryParameter("foo", "bar")
 
-				controller.Get(response, request)
+				reporter.Get(response, request)
 				responseMessage = httptest.ParseResponse(response)
 			})
 

--- a/playground/playground_suite_test.go
+++ b/playground/playground_suite_test.go
@@ -81,7 +81,7 @@ func (mock *ReadWriteResourceMock) HeadShouldHaveBeenCalled() {
 	ExpectWithOffset(1, mock.headCalled).To(BeTrue())
 }
 
-func (mock *ReadWriteResourceMock) Post(client io.Writer, target string) {
+func (mock *ReadWriteResourceMock) Post(client io.Writer, message http.RequestMessage) {
 	mock.postCalled = true
 }
 
@@ -89,7 +89,7 @@ func (mock *ReadWriteResourceMock) PostShouldHaveBeenCalled() {
 	ExpectWithOffset(1, mock.postCalled).To(BeTrue())
 }
 
-func (mock *ReadWriteResourceMock) Put(client io.Writer, target string) {
+func (mock *ReadWriteResourceMock) Put(client io.Writer, message http.RequestMessage) {
 	mock.putCalled = true
 }
 

--- a/playground/singleton.go
+++ b/playground/singleton.go
@@ -1,3 +1,0 @@
-package playground
-
-//TODO KDK: make NewPutTargetRoute

--- a/playground/singleton.go
+++ b/playground/singleton.go
@@ -1,0 +1,3 @@
+package playground
+
+//TODO KDK: make NewPutTargetRoute

--- a/playground/writable_route.go
+++ b/playground/writable_route.go
@@ -30,8 +30,8 @@ type ReadWriteResource interface {
 	Name() string
 	Get(client io.Writer, message http.RequestMessage)
 	Head(client io.Writer, message http.RequestMessage)
-	Post(client io.Writer, target string)
-	Put(client io.Writer, target string)
+	Post(client io.Writer, message http.RequestMessage)
+	Put(client io.Writer, message http.RequestMessage)
 }
 
 // Handles various read/write requests, but doesn't actually do anything
@@ -49,11 +49,11 @@ func (controller *ReadWriteNopResource) Head(client io.Writer, message http.Requ
 	writeOKWithNoBody(client)
 }
 
-func (controller *ReadWriteNopResource) Post(client io.Writer, target string) {
+func (controller *ReadWriteNopResource) Post(client io.Writer, message http.RequestMessage) {
 	writeOKWithNoBody(client)
 }
 
-func (controller *ReadWriteNopResource) Put(client io.Writer, target string) {
+func (controller *ReadWriteNopResource) Put(client io.Writer, message http.RequestMessage) {
 	writeOKWithNoBody(client)
 }
 

--- a/playground/writable_route_test.go
+++ b/playground/writable_route_test.go
@@ -113,7 +113,7 @@ var _ = Describe("ReadWriteNopResource", func() {
 
 	Describe("#Post", func() {
 		BeforeEach(func() {
-			controller.Post(response, "/")
+			controller.Post(response, http.NewPostMessage("/"))
 		})
 
 		It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
@@ -121,7 +121,7 @@ var _ = Describe("ReadWriteNopResource", func() {
 
 	Describe("#Put", func() {
 		BeforeEach(func() {
-			controller.Put(response, "/")
+			controller.Put(response, http.NewPutMessage("/"))
 		})
 
 		It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))


### PR DESCRIPTION
## Summary

Just enough to get `SimplePost` and `SimplePut` to pass.  This review adds `playground.SingletonForm`.

The next several tests look like they will have web forms at various paths that manage a single resource, so I'm planning to extend `SingletonForm` to retain and return data to subsequent queries.

## Test results

```
**Starting Test System: slim using fitnesse.slim.SlimService.
. 16:53:04 R:0    W:0    I:0    E:0    SuiteSetUp       (HttpTestSuite.SuiteSetUp)      0.002 seconds
F 16:53:04 R:1    W:6    I:0    E:0    BasicAuth        (HttpTestSuite.ResponseTestSuite.BasicAuth)     0.001 seconds
F 16:53:04 R:0    W:4    I:0    E:1    CookieData       (HttpTestSuite.ResponseTestSuite.CookieData)    0.001 seconds
F 16:53:04 R:2    W:8    I:0    E:0    CreateReadUpdateDelete   (HttpTestSuite.ResponseTestSuite.CreateReadUpdateDelete)        0.000 seconds
. 16:53:04 R:6    W:0    I:0    E:0    DirectoryLinks   (HttpTestSuite.ResponseTestSuite.DirectoryLinks)        0.001 seconds
. 16:53:04 R:1    W:0    I:0    E:0    DirectoryListing (HttpTestSuite.ResponseTestSuite.DirectoryListing)      0.000 seconds
. 16:53:04 R:1    W:0    I:0    E:0    FileContents     (HttpTestSuite.ResponseTestSuite.FileContents)  0.001 seconds
. 16:53:04 R:3    W:0    I:0    E:0    FourEightTeen    (HttpTestSuite.ResponseTestSuite.FourEightTeen) 0.000 seconds
. 16:53:04 R:1    W:0    I:0    E:0    FourOhFour       (HttpTestSuite.ResponseTestSuite.FourOhFour)    0.000 seconds
. 16:53:04 R:3    W:0    I:0    E:0    ImageContent     (HttpTestSuite.ResponseTestSuite.ImageContent)  0.001 seconds
. 16:53:04 R:4    W:0    I:0    E:0    MediaTypes       (HttpTestSuite.ResponseTestSuite.MediaTypes)    0.001 seconds
. 16:53:04 R:6    W:0    I:0    E:0    MethodNotAllowed (HttpTestSuite.ResponseTestSuite.MethodNotAllowed)      0.001 seconds
. 16:53:04 R:2    W:0    I:0    E:0    ParameterDecode  (HttpTestSuite.ResponseTestSuite.ParameterDecode)       0.000 seconds
. 16:53:04 R:11   W:0    I:0    E:0    PartialContent   (HttpTestSuite.ResponseTestSuite.PartialContent)        0.001 seconds
F 16:53:04 R:4    W:2    I:0    E:0    PatchWithEtag    (HttpTestSuite.ResponseTestSuite.PatchWithEtag) 0.001 seconds
. 16:53:04 R:2    W:0    I:0    E:0    RedirectPath     (HttpTestSuite.ResponseTestSuite.RedirectPath)  0.000 seconds
. 16:53:04 R:1    W:0    I:0    E:0    SimpleGet        (HttpTestSuite.ResponseTestSuite.SimpleGet)     0.000 seconds
. 16:53:04 R:4    W:0    I:0    E:0    SimpleHead       (HttpTestSuite.ResponseTestSuite.SimpleHead)    0.000 seconds
. 16:53:04 R:6    W:0    I:0    E:0    SimpleOption     (HttpTestSuite.ResponseTestSuite.SimpleOption)  0.001 seconds
. 16:53:04 R:1    W:0    I:0    E:0    SimplePost       (HttpTestSuite.ResponseTestSuite.SimplePost)    0.000 seconds
. 16:53:04 R:1    W:0    I:0    E:0    SimplePut        (HttpTestSuite.ResponseTestSuite.SimplePut)     0.000 seconds
. 16:53:05 R:1    W:0    I:0    E:0    TimeToComplete   (HttpTestSuite.SimultaneousTestSuite.TimeToComplete)    0.001 seconds
. 16:53:05 R:0    W:0    I:0    E:0    SuiteTearDown    (HttpTestSuite.SuiteTearDown)   0.001 seconds
--------
23 Tests,       5 Failures      4.062 seconds.
0
Exit-Code: 4
**
```