### PR TITLE
BasicAuth for /logs

### DIFF
--- a/http/logging.go
+++ b/http/logging.go
@@ -22,10 +22,11 @@ type TextLogger struct {
 }
 
 func (logger TextLogger) Parsed(message RequestMessage) {
-	fmt.Fprintf(logger.buffer, "\n%s : %s %s\n",
+	fmt.Fprintf(logger.buffer, "\n%s : %s %s %s\n",
 		time.Now().Format("2006-01-02 03:04:05 Z07:00"),
 		message.Method(),
-		message.Target())
+		message.Target(),
+		message.Version())
 	for _, header := range message.HeaderLines() {
 		fmt.Fprintln(logger.buffer, header)
 	}

--- a/http/logging.go
+++ b/http/logging.go
@@ -15,6 +15,14 @@ type TextLogger struct {
 	Writer io.Writer
 }
 
+func (logger TextLogger) Length() int {
+	panic("implement me")
+}
+
+func (logger TextLogger) WriteLoggedRequests(client io.Writer) {
+	panic("implement me")
+}
+
 func (logger TextLogger) Parsed(message RequestMessage) {
 	fmt.Fprintf(logger.Writer, "\n%s : %s %s\n",
 		time.Now().Format("2006-01-02 03:04:05 Z07:00"),

--- a/http/logging_test.go
+++ b/http/logging_test.go
@@ -12,13 +12,13 @@ import (
 var _ = Describe("TextLogger", func() {
 	Describe("#Parsed", func() {
 		var (
-			logger http.RequestLogger
+			logger *http.TextLogger
 			output *bytes.Buffer
 		)
 
 		BeforeEach(func() {
 			output = &bytes.Buffer{}
-			logger = http.TextLogger{Writer: output}
+			logger = http.NewBufferedRequestLogger()
 
 			requestMessage := &httptest.RequestMessage{
 				MethodReturns: "GET",
@@ -27,6 +27,7 @@ var _ = Describe("TextLogger", func() {
 			requestMessage.AddHeader("Content-Type", "text/plain")
 
 			logger.Parsed(requestMessage)
+			logger.WriteTo(output)
 		})
 
 		It("writes the request method and target", func() {

--- a/http/messages.go
+++ b/http/messages.go
@@ -25,27 +25,27 @@ const (
 
 func NewDeleteMessage(path string) RequestMessage {
 	return &requestMessage{
-		method: DELETE,
-		target: path,
-		path:   path,
+		method:  DELETE,
+		target:  path,
+		path:    path,
 		version: VERSION_1_1,
 	}
 }
 
 func NewGetMessage(path string) RequestMessage {
 	return &requestMessage{
-		method: GET,
-		target: path,
-		path:   path,
+		method:  GET,
+		target:  path,
+		path:    path,
 		version: VERSION_1_1,
 	}
 }
 
 func NewHeadMessage(path string) RequestMessage {
 	return &requestMessage{
-		method: HEAD,
-		target: path,
-		path:   path,
+		method:  HEAD,
+		target:  path,
+		path:    path,
 		version: VERSION_1_1,
 	}
 }
@@ -54,45 +54,45 @@ func NewHeadMessage(path string) RequestMessage {
 // or an asterisk-form query of the server as a whole (https://tools.ietf.org/html/rfc7230#section-5.3.4).
 func NewOptionsMessage(targetAsteriskOrPath string) RequestMessage {
 	return &requestMessage{
-		method: OPTIONS,
-		target: targetAsteriskOrPath,
-		path:   targetAsteriskOrPath,
+		method:  OPTIONS,
+		target:  targetAsteriskOrPath,
+		path:    targetAsteriskOrPath,
 		version: VERSION_1_1,
 	}
 }
 
 func NewPostMessage(path string) RequestMessage {
 	return &requestMessage{
-		method: POST,
-		target: path,
-		path:   path,
+		method:  POST,
+		target:  path,
+		path:    path,
 		version: VERSION_1_1,
 	}
 }
 
 func NewPutMessage(path string) RequestMessage {
 	return &requestMessage{
-		method: PUT,
-		target: path,
-		path:   path,
+		method:  PUT,
+		target:  path,
+		path:    path,
 		version: VERSION_1_1,
 	}
 }
 
 func NewTraceMessage(path string) RequestMessage {
 	return &requestMessage{
-		method: TRACE,
-		target: path,
-		path:   path,
+		method:  TRACE,
+		target:  path,
+		path:    path,
 		version: VERSION_1_1,
 	}
 }
 
 func NewRequestMessage(method, path string) RequestMessage {
 	return &requestMessage{
-		method: method,
-		target: path,
-		path:   path,
+		method:  method,
+		target:  path,
+		path:    path,
 		version: VERSION_1_1,
 	}
 }

--- a/http/messages.go
+++ b/http/messages.go
@@ -19,11 +19,16 @@ const (
 	TRACE   string = "TRACE"
 )
 
+const (
+	VERSION_1_1 string = "HTTP/1.1"
+)
+
 func NewDeleteMessage(path string) RequestMessage {
 	return &requestMessage{
 		method: DELETE,
 		target: path,
 		path:   path,
+		version: VERSION_1_1,
 	}
 }
 
@@ -32,6 +37,7 @@ func NewGetMessage(path string) RequestMessage {
 		method: GET,
 		target: path,
 		path:   path,
+		version: VERSION_1_1,
 	}
 }
 
@@ -40,6 +46,7 @@ func NewHeadMessage(path string) RequestMessage {
 		method: HEAD,
 		target: path,
 		path:   path,
+		version: VERSION_1_1,
 	}
 }
 
@@ -50,6 +57,7 @@ func NewOptionsMessage(targetAsteriskOrPath string) RequestMessage {
 		method: OPTIONS,
 		target: targetAsteriskOrPath,
 		path:   targetAsteriskOrPath,
+		version: VERSION_1_1,
 	}
 }
 
@@ -58,6 +66,7 @@ func NewPostMessage(path string) RequestMessage {
 		method: POST,
 		target: path,
 		path:   path,
+		version: VERSION_1_1,
 	}
 }
 
@@ -66,6 +75,7 @@ func NewPutMessage(path string) RequestMessage {
 		method: PUT,
 		target: path,
 		path:   path,
+		version: VERSION_1_1,
 	}
 }
 
@@ -74,6 +84,7 @@ func NewTraceMessage(path string) RequestMessage {
 		method: TRACE,
 		target: path,
 		path:   path,
+		version: VERSION_1_1,
 	}
 }
 
@@ -82,6 +93,7 @@ func NewRequestMessage(method, path string) RequestMessage {
 		method: method,
 		target: path,
 		path:   path,
+		version: VERSION_1_1,
 	}
 }
 
@@ -89,6 +101,7 @@ type requestMessage struct {
 	method          string
 	path            string
 	target          string
+	version         string
 	queryParameters []QueryParameter
 	headers         []header
 	body            []byte
@@ -100,6 +113,10 @@ func (message *requestMessage) Method() string {
 
 func (message *requestMessage) Path() string {
 	return message.path
+}
+
+func (message *requestMessage) Version() string {
+	return message.version
 }
 
 func (message *requestMessage) AddQueryFlag(name string) {
@@ -183,7 +200,7 @@ func (message *requestMessage) unsupportedMethod(resource Resource) Request {
 func (message *requestMessage) supportedMethods(resource Resource) []string {
 	supported := []string{OPTIONS}
 	for name, method := range knownMethods {
-		imaginaryRequest := &requestMessage{method: name, target: message.target}
+		imaginaryRequest := &requestMessage{method: name, target: message.target, version: message.version}
 		_, isSupported := method.MakeRequest(imaginaryRequest, resource)
 		if isSupported {
 			supported = append(supported, name)

--- a/http/parser.go
+++ b/http/parser.go
@@ -37,15 +37,16 @@ func (parser *parseMethodObject) parsingRequestLine(requestLine string) (ok *req
 		return nil, &clienterror.BadRequest{DisplayText: "incorrectly formatted or missing request-line"}
 	}
 
-	return parser.parsingTarget(fields[0], fields[1])
+	return parser.parsingTarget(fields[0], fields[1], fields[2])
 }
 
-func (parser *parseMethodObject) parsingTarget(method, target string) (ok *requestMessage, badRequest Response) {
+func (parser *parseMethodObject) parsingTarget(method, target, version string) (ok *requestMessage, badRequest Response) {
 	path, query, _ := splitTarget(target)
 	requested := &requestMessage{
-		method: method,
-		target: target,
-		path:   path,
+		method:  method,
+		target:  target,
+		path:    path,
+		version: version,
 	}
 
 	return parser.parsingQueryString(requested, query)

--- a/http/router.go
+++ b/http/router.go
@@ -64,6 +64,7 @@ type RequestLogger interface {
 type RequestMessage interface {
 	Method() string
 	Target() string
+	Version() string
 	Path() string
 	QueryParameters() []QueryParameter
 

--- a/http/router.go
+++ b/http/router.go
@@ -82,3 +82,8 @@ type Route interface {
 type QueryParameter struct {
 	Name, Value string
 }
+
+// A null object for RequestLogger that does nothing
+type noLogger struct{}
+
+func (noLogger) Parsed(message RequestMessage) {}

--- a/httptest/request_message.go
+++ b/httptest/request_message.go
@@ -10,9 +10,10 @@ import (
 )
 
 type RequestMessage struct {
-	MethodReturns string
-	PathReturns   string
-	TargetReturns string
+	MethodReturns  string
+	PathReturns    string
+	TargetReturns  string
+	VersionReturns string
 
 	MakeResourceRequestReturns  http.Request
 	makeResourceRequestReceived http.Resource
@@ -35,7 +36,7 @@ func (message *RequestMessage) Target() string {
 }
 
 func (message *RequestMessage) Version() string {
-	return http.VERSION_1_1
+	return message.VersionReturns
 }
 
 func (message *RequestMessage) AddQueryParameter(name string, value string) {

--- a/httptest/request_message.go
+++ b/httptest/request_message.go
@@ -34,6 +34,10 @@ func (message *RequestMessage) Target() string {
 	return message.TargetReturns
 }
 
+func (message *RequestMessage) Version() string {
+	return http.VERSION_1_1
+}
+
 func (message *RequestMessage) AddQueryParameter(name string, value string) {
 	message.queryParameters = append(message.queryParameters, http.QueryParameter{Name: name, Value: value})
 }

--- a/log/doc.go
+++ b/log/doc.go
@@ -1,0 +1,2 @@
+// Access to request logs
+package log

--- a/log/log_route.go
+++ b/log/log_route.go
@@ -1,7 +1,11 @@
 package log
 
 import (
+	"io"
+
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/msg"
+	"github.com/kkrull/gohttp/msg/clienterror"
 )
 
 func NewLogRoute(path string) http.Route {
@@ -29,4 +33,10 @@ type Viewer struct{}
 
 func (viewer *Viewer) Name() string {
 	return "Log viewer"
+}
+
+func (viewer *Viewer) Get(client io.Writer, message http.RequestMessage) {
+	msg.WriteStatus(client, clienterror.UnauthorizedStatus)
+	msg.WriteHeader(client, "WWW-Authenticate", "Basic realm=\"logs\"")
+	msg.WriteEndOfMessageHeader(client)
 }

--- a/log/log_route.go
+++ b/log/log_route.go
@@ -47,6 +47,10 @@ func (viewer *Viewer) Get(client io.Writer, message http.RequestMessage) {
 		msg.WriteHeader(client, "WWW-Authenticate", "Basic realm=\"logs\"")
 		msg.WriteEndOfMessageHeader(client)
 		return
+	} else if len(authorizations) > 1 {
+		msg.WriteStatus(client, clienterror.BadRequestStatus)
+		msg.WriteEndOfMessageHeader(client)
+		return
 	}
 
 	firstAuthorization := authorizations[0]

--- a/log/log_route.go
+++ b/log/log_route.go
@@ -1,13 +1,32 @@
 package log
 
-import "github.com/kkrull/gohttp/http"
+import (
+	"github.com/kkrull/gohttp/http"
+)
 
 func NewLogRoute(path string) http.Route {
-	return &Route{}
+	return &Route{
+		Path:   path,
+		Viewer: &Viewer{},
+	}
 }
 
-type Route struct{}
+type Route struct {
+	Path   string
+	Viewer *Viewer
+}
 
 func (route *Route) Route(requested http.RequestMessage) http.Request {
-	panic("implement me")
+	if requested.Path() != route.Path {
+		return nil
+	}
+
+	return requested.MakeResourceRequest(route.Viewer)
+}
+
+// Views server logs
+type Viewer struct{}
+
+func (viewer *Viewer) Name() string {
+	return "Log viewer"
 }

--- a/log/log_route.go
+++ b/log/log_route.go
@@ -1,0 +1,13 @@
+package log
+
+import "github.com/kkrull/gohttp/http"
+
+func NewLogRoute(path string) http.Route {
+	return &Route{}
+}
+
+type Route struct{}
+
+func (route *Route) Route(requested http.RequestMessage) http.Request {
+	panic("implement me")
+}

--- a/log/log_route_test.go
+++ b/log/log_route_test.go
@@ -1,8 +1,12 @@
 package log_test
 
 import (
+	"bytes"
+
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/httptest"
 	"github.com/kkrull/gohttp/log"
+	"github.com/kkrull/gohttp/msg/clienterror"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -11,18 +15,48 @@ var _ = Describe("::NewLogRoute", func() {
 	It("returns a Route at the given path", func() {
 		route := log.NewLogRoute("/foo")
 		Expect(route).NotTo(BeNil())
-		Expect(route).To(BeEquivalentTo(&log.Route{}))
+		Expect(route).To(BeEquivalentTo(&log.Route{
+			Path:   "/foo",
+			Viewer: &log.Viewer{},
+		}))
 	})
 })
 
 var _ = Describe("Route", func() {
+	const (
+		configuredPath = "/logs"
+	)
+
 	var (
-		router http.Route
+		router   http.Route
+		response = &bytes.Buffer{}
 	)
 
 	Describe("#Route", func() {
 		BeforeEach(func() {
-			router = &log.Route{}
+			router = &log.Route{Path: configuredPath}
+			response.Reset()
+		})
+
+		Context("when the path is the given path", func() {
+			Context("when the method is OPTIONS", func() {
+				BeforeEach(func() {
+					requested := http.NewOptionsMessage(configuredPath)
+					routedRequest := router.Route(requested)
+					Expect(routedRequest).NotTo(BeNil())
+					routedRequest.Handle(response)
+				})
+
+				It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
+				It("allows OPTIONS", httptest.ShouldAllowMethods(response, http.OPTIONS))
+				It("allows GET", httptest.ShouldAllowMethods(response, http.GET))
+			})
+
+			It("replies Method Not Allowed on any other method", func() {
+				requested := http.NewTraceMessage(configuredPath)
+				routedRequest := router.Route(requested)
+				Expect(routedRequest).To(BeAssignableToTypeOf(clienterror.MethodNotAllowed()))
+			})
 		})
 
 		It("passes on any other path by returning nil", func() {

--- a/log/log_route_test.go
+++ b/log/log_route_test.go
@@ -1,0 +1,33 @@
+package log_test
+
+import (
+	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/log"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("::NewLogRoute", func() {
+	It("returns a Route at the given path", func() {
+		route := log.NewLogRoute("/foo")
+		Expect(route).NotTo(BeNil())
+		Expect(route).To(BeEquivalentTo(&log.Route{}))
+	})
+})
+
+var _ = Describe("Route", func() {
+	var (
+		router http.Route
+	)
+
+	Describe("#Route", func() {
+		BeforeEach(func() {
+			router = &log.Route{}
+		})
+
+		It("passes on any other path by returning nil", func() {
+			requested := http.NewGetMessage("/")
+			Expect(router.Route(requested)).To(BeNil())
+		})
+	})
+})

--- a/log/log_route_test.go
+++ b/log/log_route_test.go
@@ -15,14 +15,16 @@ import (
 const configuredPath = "/logs"
 
 var _ = Describe("::NewLogRoute", func() {
-	It("returns a Route at the given path", func() {
+	It("returns a Route at the given path for logs available to one with the appropriate credentials", func() {
 		logger := &RequestBufferStub{}
 		route := log.NewLogRoute("/foo", logger)
 		Expect(route).NotTo(BeNil())
 		Expect(route).To(BeEquivalentTo(&log.Route{
 			Path: "/foo",
 			Viewer: &log.Viewer{
-				Requests: logger,
+				Requests:           logger,
+				AuthorizedUser:     "admin",
+				AuthorizedPassword: "hunter2",
 			},
 		}))
 	})
@@ -80,7 +82,11 @@ var _ = Describe("Viewer", func() {
 			NumBytesReturns: 4,
 			WriteToWill:     bytes.NewBufferString("ASDF"),
 		}
-		viewer = &log.Viewer{Requests: logger}
+		viewer = &log.Viewer{
+			Requests:           logger,
+			AuthorizedUser:     "admin",
+			AuthorizedPassword: "hunter2",
+		}
 	})
 
 	Describe("#Get", func() {

--- a/log/log_route_test.go
+++ b/log/log_route_test.go
@@ -16,11 +16,14 @@ const configuredPath = "/logs"
 
 var _ = Describe("::NewLogRoute", func() {
 	It("returns a Route at the given path", func() {
-		route := log.NewLogRoute("/foo")
+		logger := &WriterMock{}
+		route := log.NewLogRoute("/foo", logger)
 		Expect(route).NotTo(BeNil())
 		Expect(route).To(BeEquivalentTo(&log.Route{
-			Path:   "/foo",
-			Viewer: &log.Viewer{},
+			Path: "/foo",
+			Viewer: &log.Viewer{
+				RequestLog: logger,
+			},
 		}))
 	})
 })
@@ -68,11 +71,13 @@ var _ = Describe("Route", func() {
 var _ = Describe("Viewer", func() {
 	var (
 		viewer   *log.Viewer
+		logger   log.Writer
 		response *httptest.ResponseMessage
 	)
 
 	BeforeEach(func() {
-		viewer = &log.Viewer{}
+		logger = &WriterMock{}
+		viewer = &log.Viewer{RequestLog: logger}
 	})
 
 	Describe("#Get", func() {

--- a/log/log_suite_test.go
+++ b/log/log_suite_test.go
@@ -1,0 +1,13 @@
+package log_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "log")
+}

--- a/log/log_suite_test.go
+++ b/log/log_suite_test.go
@@ -1,6 +1,7 @@
 package log_test
 
 import (
+	"io"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -11,3 +12,13 @@ func TestLog(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "log")
 }
+
+/* WriterMock */
+
+type WriterMock struct{}
+
+func (mock *WriterMock) Length() int {
+	return 0
+}
+
+func (mock *WriterMock) WriteLoggedRequests(client io.Writer) {}

--- a/log/log_suite_test.go
+++ b/log/log_suite_test.go
@@ -1,6 +1,7 @@
 package log_test
 
 import (
+	"bytes"
 	"io"
 	"testing"
 
@@ -13,12 +14,17 @@ func TestLog(t *testing.T) {
 	RunSpecs(t, "log")
 }
 
-/* WriterMock */
+/* RequestBufferStub */
 
-type WriterMock struct{}
-
-func (mock *WriterMock) Length() int {
-	return 0
+type RequestBufferStub struct {
+	NumBytesReturns int
+	WriteToWill     *bytes.Buffer
 }
 
-func (mock *WriterMock) WriteLoggedRequests(client io.Writer) {}
+func (stub *RequestBufferStub) NumBytes() int {
+	return stub.NumBytesReturns
+}
+
+func (stub *RequestBufferStub) WriteTo(client io.Writer) {
+	stub.WriteToWill.WriteTo(client)
+}

--- a/log/logging.go
+++ b/log/logging.go
@@ -1,16 +1,13 @@
-package http
+package log
 
 import (
 	"bytes"
 	"fmt"
 	"io"
 	"time"
+
+	"github.com/kkrull/gohttp/http"
 )
-
-// A null object for RequestLogger that does nothing
-type noLogger struct{}
-
-func (noLogger) Parsed(message RequestMessage) {}
 
 func NewBufferedRequestLogger() *TextLogger {
 	return &TextLogger{buffer: &bytes.Buffer{}}
@@ -21,7 +18,7 @@ type TextLogger struct {
 	buffer *bytes.Buffer
 }
 
-func (logger TextLogger) Parsed(message RequestMessage) {
+func (logger TextLogger) Parsed(message http.RequestMessage) {
 	fmt.Fprintf(logger.buffer, "\n%s : %s %s %s\n",
 		time.Now().Format("2006-01-02 03:04:05 Z07:00"),
 		message.Method(),

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -21,8 +21,9 @@ var _ = Describe("TextLogger", func() {
 			logger = log.NewBufferedRequestLogger()
 
 			requestMessage := &httptest.RequestMessage{
-				MethodReturns: "GET",
-				TargetReturns: "/foo",
+				MethodReturns:  "GET",
+				TargetReturns:  "/foo",
+				VersionReturns: "HTTP/1.1",
 			}
 			requestMessage.AddHeader("Content-Type", "text/plain")
 
@@ -31,7 +32,7 @@ var _ = Describe("TextLogger", func() {
 		})
 
 		It("writes the request method and target", func() {
-			Expect(output.String()).To(ContainSubstring("GET /foo"))
+			Expect(output.String()).To(ContainSubstring("GET /foo HTTP/1.1"))
 		})
 		It("writes each header line", func() {
 			Expect(output.String()).To(MatchRegexp("Content-Type: text/plain"))

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -1,10 +1,10 @@
-package http_test
+package log_test
 
 import (
 	"bytes"
 
-	"github.com/kkrull/gohttp/http"
 	"github.com/kkrull/gohttp/httptest"
+	"github.com/kkrull/gohttp/log"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,13 +12,13 @@ import (
 var _ = Describe("TextLogger", func() {
 	Describe("#Parsed", func() {
 		var (
-			logger *http.TextLogger
+			logger *log.TextLogger
 			output *bytes.Buffer
 		)
 
 		BeforeEach(func() {
 			output = &bytes.Buffer{}
-			logger = http.NewBufferedRequestLogger()
+			logger = log.NewBufferedRequestLogger()
 
 			requestMessage := &httptest.RequestMessage{
 				MethodReturns: "GET",

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kkrull/gohttp/capability"
 	"github.com/kkrull/gohttp/fs"
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/log"
 	"github.com/kkrull/gohttp/playground"
 	"github.com/kkrull/gohttp/teapot"
 )
@@ -47,6 +48,7 @@ func (factory *InterruptFactory) TCPServer(contentRootPath string, host string, 
 func (factory *InterruptFactory) routerWithAllRoutes(contentRootPath string) http.Router {
 	router := http.NewRouter()
 	router.AddRoute(capability.NewRoute())
+	router.AddRoute(log.NewLogRoute("/logs"))
 	router.AddRoute(playground.NewSingletonRoute("/cat-form"))
 	router.AddRoute(playground.NewWriteOKRoute("/form"))
 	router.AddRoute(playground.NewWriteOKRoute("/put-target"))

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"flag"
 	"os"
 
@@ -47,8 +48,13 @@ func (factory *InterruptFactory) TCPServer(contentRootPath string, host string, 
 
 func (factory *InterruptFactory) routerWithAllRoutes(contentRootPath string) http.Router {
 	router := http.NewRouter()
+
+	buffer := &bytes.Buffer{}
+	logger := &http.TextLogger{Writer: buffer}
+	router.LogRequests(logger)
+
 	router.AddRoute(capability.NewRoute())
-	router.AddRoute(log.NewLogRoute("/logs"))
+	router.AddRoute(log.NewLogRoute("/logs", logger))
 	router.AddRoute(playground.NewSingletonRoute("/cat-form"))
 	router.AddRoute(playground.NewWriteOKRoute("/form"))
 	router.AddRoute(playground.NewWriteOKRoute("/put-target"))

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"flag"
 	"os"
 
@@ -49,8 +48,7 @@ func (factory *InterruptFactory) TCPServer(contentRootPath string, host string, 
 func (factory *InterruptFactory) routerWithAllRoutes(contentRootPath string) http.Router {
 	router := http.NewRouter()
 
-	buffer := &bytes.Buffer{}
-	logger := &http.TextLogger{Writer: buffer}
+	logger := http.NewBufferedRequestLogger()
 	router.LogRequests(logger)
 
 	router.AddRoute(capability.NewRoute())

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -48,7 +48,7 @@ func (factory *InterruptFactory) TCPServer(contentRootPath string, host string, 
 func (factory *InterruptFactory) routerWithAllRoutes(contentRootPath string) http.Router {
 	router := http.NewRouter()
 
-	logger := http.NewBufferedRequestLogger()
+	logger := log.NewBufferedRequestLogger()
 	router.LogRequests(logger)
 
 	router.AddRoute(capability.NewRoute())

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -96,7 +96,7 @@ var _ = Describe("InterruptFactory", func() {
 			Expect(typedServer.Routes()).To(ContainElement(BeEquivalentTo(
 				log.NewLogRoute(
 					"/logs",
-					http.NewBufferedRequestLogger(),
+					log.NewBufferedRequestLogger(),
 				))))
 		})
 

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -1,7 +1,6 @@
 package cmd_test
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"os"
@@ -97,7 +96,7 @@ var _ = Describe("InterruptFactory", func() {
 			Expect(typedServer.Routes()).To(ContainElement(BeEquivalentTo(
 				log.NewLogRoute(
 					"/logs",
-					&http.TextLogger{&bytes.Buffer{}},
+					http.NewBufferedRequestLogger(),
 				))))
 		})
 

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
@@ -93,7 +94,11 @@ var _ = Describe("InterruptFactory", func() {
 		})
 
 		It("has a log route at /logs", func() {
-			Expect(typedServer.Routes()).To(ContainElement(BeEquivalentTo(log.NewLogRoute("/logs"))))
+			Expect(typedServer.Routes()).To(ContainElement(BeEquivalentTo(
+				log.NewLogRoute(
+					"/logs",
+					&http.TextLogger{&bytes.Buffer{}},
+				))))
 		})
 
 		It("has a playground write-only route at /form", func() {

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kkrull/gohttp/capability"
 	"github.com/kkrull/gohttp/fs"
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/log"
 	"github.com/kkrull/gohttp/main/cmd"
 	"github.com/kkrull/gohttp/playground"
 	"github.com/kkrull/gohttp/teapot"
@@ -89,6 +90,10 @@ var _ = Describe("InterruptFactory", func() {
 
 		It("has a capabilities route", func() {
 			Expect(typedServer.Routes()).To(ContainElement(BeAssignableToTypeOf(capability.NewRoute())))
+		})
+
+		It("has a log route at /logs", func() {
+			Expect(typedServer.Routes()).To(ContainElement(BeEquivalentTo(log.NewLogRoute("/logs"))))
 		})
 
 		It("has a playground write-only route at /form", func() {

--- a/msg/clienterror/status.go
+++ b/msg/clienterror/status.go
@@ -5,6 +5,7 @@ import "github.com/kkrull/gohttp/msg"
 var (
 	BadRequestStatus          = msg.Status{400, "Bad Request"}
 	UnauthorizedStatus        = msg.Status{401, "Unauthorized"}
+	ForbiddenStatus           = msg.Status{403, "Forbidden"}
 	NotFoundStatus            = msg.Status{404, "Not Found"}
 	MethodNotAllowedStatus    = msg.Status{405, "Method Not Allowed"}
 	RangeNotSatisfiableStatus = msg.Status{416, "Range Not Satisfiable"}

--- a/msg/clienterror/status.go
+++ b/msg/clienterror/status.go
@@ -4,6 +4,7 @@ import "github.com/kkrull/gohttp/msg"
 
 var (
 	BadRequestStatus          = msg.Status{400, "Bad Request"}
+	UnauthorizedStatus        = msg.Status{401, "Unauthorized"}
 	NotFoundStatus            = msg.Status{404, "Not Found"}
 	MethodNotAllowedStatus    = msg.Status{405, "Method Not Allowed"}
 	RangeNotSatisfiableStatus = msg.Status{416, "Range Not Satisfiable"}


### PR DESCRIPTION
## Summary

* Added `logs.Route` to handle authorized requests to `/logs`
* `TextLogger` now maintains a buffer so it can write out log messages for whatever has been requested in this gohttp process, instead of writing immediately to `os.Stdout`.

## Test results

```
Starting Test System: slim using fitnesse.slim.SlimService.
. 16:49:04 R:0    W:0    I:0    E:0    SuiteSetUp       (HttpTestSuite.SuiteSetUp)      0.003 seconds
. 16:49:05 R:7    W:0    I:0    E:0    BasicAuth        (HttpTestSuite.ResponseTestSuite.BasicAuth)     0.001 seconds
F 16:49:05 R:0    W:4    I:0    E:1    CookieData       (HttpTestSuite.ResponseTestSuite.CookieData)    0.000 seconds
. 16:49:05 R:10   W:0    I:0    E:0    CreateReadUpdateDelete   (HttpTestSuite.ResponseTestSuite.CreateReadUpdateDelete)        0.000 seconds
. 16:49:05 R:6    W:0    I:0    E:0    DirectoryLinks   (HttpTestSuite.ResponseTestSuite.DirectoryLinks)        0.001 seconds
. 16:49:05 R:1    W:0    I:0    E:0    DirectoryListing (HttpTestSuite.ResponseTestSuite.DirectoryListing)      0.000 seconds
. 16:49:05 R:1    W:0    I:0    E:0    FileContents     (HttpTestSuite.ResponseTestSuite.FileContents)  0.001 seconds
. 16:49:05 R:3    W:0    I:0    E:0    FourEightTeen    (HttpTestSuite.ResponseTestSuite.FourEightTeen) 0.000 seconds
. 16:49:05 R:1    W:0    I:0    E:0    FourOhFour       (HttpTestSuite.ResponseTestSuite.FourOhFour)    0.000 seconds
. 16:49:05 R:3    W:0    I:0    E:0    ImageContent     (HttpTestSuite.ResponseTestSuite.ImageContent)  0.001 seconds
. 16:49:05 R:4    W:0    I:0    E:0    MediaTypes       (HttpTestSuite.ResponseTestSuite.MediaTypes)    0.002 seconds
. 16:49:05 R:6    W:0    I:0    E:0    MethodNotAllowed (HttpTestSuite.ResponseTestSuite.MethodNotAllowed)      0.000 seconds
. 16:49:05 R:2    W:0    I:0    E:0    ParameterDecode  (HttpTestSuite.ResponseTestSuite.ParameterDecode)       0.000 seconds
. 16:49:05 R:11   W:0    I:0    E:0    PartialContent   (HttpTestSuite.ResponseTestSuite.PartialContent)        0.000 seconds
F 16:49:05 R:4    W:2    I:0    E:0    PatchWithEtag    (HttpTestSuite.ResponseTestSuite.PatchWithEtag) 0.000 seconds
. 16:49:05 R:2    W:0    I:0    E:0    RedirectPath     (HttpTestSuite.ResponseTestSuite.RedirectPath)  0.001 seconds
. 16:49:05 R:1    W:0    I:0    E:0    SimpleGet        (HttpTestSuite.ResponseTestSuite.SimpleGet)     0.000 seconds
. 16:49:05 R:4    W:0    I:0    E:0    SimpleHead       (HttpTestSuite.ResponseTestSuite.SimpleHead)    0.001 seconds
. 16:49:05 R:6    W:0    I:0    E:0    SimpleOption     (HttpTestSuite.ResponseTestSuite.SimpleOption)  0.001 seconds
. 16:49:05 R:1    W:0    I:0    E:0    SimplePost       (HttpTestSuite.ResponseTestSuite.SimplePost)    0.000 seconds
. 16:49:05 R:1    W:0    I:0    E:0    SimplePut        (HttpTestSuite.ResponseTestSuite.SimplePut)     0.000 seconds
. 16:49:07 R:1    W:0    I:0    E:0    TimeToComplete   (HttpTestSuite.SimultaneousTestSuite.TimeToComplete)    0.001 seconds
. 16:49:07 R:0    W:0    I:0    E:0    SuiteTearDown    (HttpTestSuite.SuiteTearDown)   0.000 seconds
--------
23 Tests,       3 Failures      4.967 seconds.
0
Exit-Code: 2
```