### PR TITLE
Cookies

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -71,3 +71,9 @@ HTTP version
 * Given HTTP/1.2+ -- should it respond with 501 Not Implemented?
   RFC 7231 seems to suggest that it's only meant for an unsupported _method_.
 * Given HTTP/2+ -- it could respond 505 HTTP Version Not Supported
+
+
+## Cookies
+
+* Sign cookies -- something like sha256
+* Encrypt cookies -- with a strong encryption algorithm and salt

--- a/backlog.md
+++ b/backlog.md
@@ -1,5 +1,11 @@
 # Developer backlog
 
+## Universal HEAD requests
+
+Any time GET is supported, HEAD should be too.  
+Come up with some general mechanism to have a default resource method that calls `GetResource#Get` and ignores the message body.
+
+
 ## Content-type missing on empty file
 
 It should probably be text/plain, but it's worth double-checking to see if there's a specification for this.
@@ -22,6 +28,12 @@ $ curl -4 -v 'http://localhost:1234/cat-form/.gitkeep' ; echo ''
 ```
 
 
+## Header-only responses
+
+A number of responses don't have or need any message body.
+Come up with a way to consistently set `Content-Length` to 0.
+
+
 ## Handling requests
 
 Missing ways to cause I/O errors with
@@ -31,11 +43,18 @@ Missing ways to cause I/O errors with
 * `os.File`
 
 
-## Naming
+## DRYness
 
-- `Controller` might be better referred to as a `Resource` that supports (HTTP) methods.
+* Invoking requests -- buffering and parsing the response message
+* Building up request messages -- a builder would come in handy
+
+
+## Routing
+
 - `package.Route` might be better called `MethodRoute` and be dedicated to de-muxing HTTP method **only**
 - `Router.Route` might be better called `ResourceRoute` and be dedicated to de-muxing over Target/Resource **only**
+- The route configuration is getting big enough that it would be handy to configure from a file instead of modifying code all the time.
+- It would be more clear which paths go to which routes/resources if each constructor takes the path(s) it serves are parameters.
 
 
 ## Request parsing

--- a/backlog.md
+++ b/backlog.md
@@ -47,6 +47,7 @@ Missing ways to cause I/O errors with
 
 * Invoking requests -- buffering and parsing the response message
 * Building up request messages -- a builder would come in handy
+* Constants for commonly-used content types
 
 
 ## Routing

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -60,6 +60,7 @@ func (factory *InterruptFactory) routerWithAllRoutes(contentRootPath string) htt
 	router.AddRoute(playground.NewReadOnlyRoute())
 	router.AddRoute(playground.NewReadWriteRoute())
 	router.AddRoute(playground.NewRedirectRoute())
+	router.AddRoute(playground.NewCookieRoute("/cookie", "/eat_cookie"))
 	router.AddRoute(teapot.NewRoute())
 	router.AddRoute(fs.NewRoute(contentRootPath))
 	return router

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -100,6 +100,10 @@ var _ = Describe("InterruptFactory", func() {
 				))))
 		})
 
+		It("has a playground route to test round trips for cookies at /cookie and /eat_cookie", func() {
+			Expect(typedServer.Routes()).To(ContainElement(BeEquivalentTo(playground.NewCookieRoute("/cookie", "/eat_cookie"))))
+		})
+
 		It("has a playground write-only route at /form", func() {
 			Expect(typedServer.Routes()).To(ContainElement(BeEquivalentTo(playground.NewWriteOKRoute("/form"))))
 		})

--- a/playground/cookie_route.go
+++ b/playground/cookie_route.go
@@ -1,6 +1,13 @@
 package playground
 
-import "github.com/kkrull/gohttp/http"
+import (
+	"fmt"
+	"io"
+
+	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/msg"
+	"github.com/kkrull/gohttp/msg/success"
+)
 
 func NewCookieRoute(setTypePath, readTypePath string) *CookieRoute {
 	return &CookieRoute{
@@ -9,11 +16,49 @@ func NewCookieRoute(setTypePath, readTypePath string) *CookieRoute {
 	}
 }
 
+// Routes to register some content to return from the server in the form of a cookie
+// and to ensure that the cookie sent back from the browser contains that content
 type CookieRoute struct {
-	SetTypePath  string
+	SetTypePath string
+	Registrar   *CookieRegistrar
+
 	ReadTypePath string
 }
 
 func (route *CookieRoute) Route(requested http.RequestMessage) http.Request {
-	return nil
+	switch requested.Path() {
+	case route.SetTypePath:
+		return requested.MakeResourceRequest(&CookieRegistrar{})
+	default:
+		return nil
+	}
+}
+
+// Registers cookies
+type CookieRegistrar struct{}
+
+func (registrar *CookieRegistrar) Name() string {
+	return "Cookie registrar"
+}
+
+func (registrar *CookieRegistrar) Get(client io.Writer, message http.RequestMessage) {
+	cookieType := findQueryParameter(message, "type")
+	msg.WriteStatus(client, success.OKStatus)
+	msg.WriteHeader(client, "Set-Cookie", cookieType)
+	msg.WriteContentTypeHeader(client, "text/plain")
+
+	body := fmt.Sprintf("Eat a %s.", cookieType)
+	msg.WriteContentLengthHeader(client, len(body))
+	msg.WriteEndOfMessageHeader(client)
+	msg.WriteBody(client, body)
+}
+
+func findQueryParameter(message http.RequestMessage, name string) string {
+	for _, parameter := range message.QueryParameters() {
+		if parameter.Name == name {
+			return parameter.Value
+		}
+	}
+
+	return ""
 }

--- a/playground/cookie_route.go
+++ b/playground/cookie_route.go
@@ -143,11 +143,6 @@ func singleQueryParameter(message http.RequestMessage, name string) (value strin
 // Stores information about cookies in memory
 type MemoryCookieLedger struct{}
 
-func (ledger *MemoryCookieLedger) PreferredType() (string, error) {
-	return "", fmt.Errorf("no preference has been defined")
-}
-
 // Keeps track of the cookie monster's preferred type of cookie
 type CookieLedger interface {
-	PreferredType() (string, error)
 }

--- a/playground/cookie_route.go
+++ b/playground/cookie_route.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kkrull/gohttp/http"
 	"github.com/kkrull/gohttp/msg"
+	"github.com/kkrull/gohttp/msg/clienterror"
 	"github.com/kkrull/gohttp/msg/success"
 )
 
@@ -42,7 +43,38 @@ func (registrar *CookieRegistrar) Name() string {
 }
 
 func (registrar *CookieRegistrar) Get(client io.Writer, message http.RequestMessage) {
-	cookieType := findQueryParameter(message, "type")
+	cookieType, err := singleQueryParameter(message, "type")
+	if err != nil {
+		invalidTypeState(client)
+	} else {
+		typeSetState(client, cookieType)
+	}
+}
+
+func singleQueryParameter(message http.RequestMessage, name string) (value string, err error) {
+	values := make([]string, 0)
+	for _, parameter := range message.QueryParameters() {
+		if parameter.Name == name {
+			values = append(values, parameter.Value)
+		}
+	}
+
+	switch len(values) {
+	case 0:
+		return "", fmt.Errorf("missing type parameter")
+	case 1:
+		return values[0], nil
+	default:
+		return "", fmt.Errorf("too many type parameters")
+	}
+}
+
+func invalidTypeState(client io.Writer) {
+	msg.WriteStatus(client, clienterror.BadRequestStatus)
+	msg.WriteEndOfMessageHeader(client)
+}
+
+func typeSetState(client io.Writer, cookieType string) {
 	msg.WriteStatus(client, success.OKStatus)
 	msg.WriteHeader(client, "Set-Cookie", cookieType)
 	msg.WriteContentTypeHeader(client, "text/plain")
@@ -51,14 +83,4 @@ func (registrar *CookieRegistrar) Get(client io.Writer, message http.RequestMess
 	msg.WriteContentLengthHeader(client, len(body))
 	msg.WriteEndOfMessageHeader(client)
 	msg.WriteBody(client, body)
-}
-
-func findQueryParameter(message http.RequestMessage, name string) string {
-	for _, parameter := range message.QueryParameters() {
-		if parameter.Name == name {
-			return parameter.Value
-		}
-	}
-
-	return ""
 }

--- a/playground/cookie_route.go
+++ b/playground/cookie_route.go
@@ -11,13 +11,12 @@ import (
 )
 
 func NewCookieRoute(setTypePath, readTypePath string) *CookieRoute {
-	ledger := &MemoryCookieLedger{}
 	return &CookieRoute{
 		SetTypePath: setTypePath,
-		Registrar:   &CookieRegistrar{Ledger: ledger},
+		Registrar:   &CookieRegistrar{},
 
 		ReadTypePath: readTypePath,
-		Monster:      &CookieMonster{Ledger: ledger},
+		Monster:      &CookieMonster{},
 	}
 }
 
@@ -43,9 +42,7 @@ func (route *CookieRoute) Route(requested http.RequestMessage) http.Request {
 }
 
 // "C" IS FOR COOKIE
-type CookieMonster struct {
-	Ledger CookieLedger
-}
+type CookieMonster struct{}
 
 func (monster *CookieMonster) Name() string {
 	return "Cookie Monster"
@@ -77,9 +74,7 @@ func (monster *CookieMonster) preferredCookieState(client io.Writer, cookieType 
 }
 
 // Registers cookies
-type CookieRegistrar struct {
-	Ledger CookieLedger
-}
+type CookieRegistrar struct{}
 
 func (registrar *CookieRegistrar) Name() string {
 	return "Cookie registrar"
@@ -156,11 +151,4 @@ type tooManyValuesError struct {
 
 func (err *tooManyValuesError) Error() string {
 	return fmt.Sprintf("too many values for %s", err.what)
-}
-
-// Stores information about cookies in memory
-type MemoryCookieLedger struct{}
-
-// Keeps track of the cookie monster's preferred type of cookie
-type CookieLedger interface {
 }

--- a/playground/cookie_route.go
+++ b/playground/cookie_route.go
@@ -1,0 +1,19 @@
+package playground
+
+import "github.com/kkrull/gohttp/http"
+
+func NewCookieRoute(setTypePath, readTypePath string) *CookieRoute {
+	return &CookieRoute{
+		SetTypePath:  setTypePath,
+		ReadTypePath: readTypePath,
+	}
+}
+
+type CookieRoute struct {
+	SetTypePath  string
+	ReadTypePath string
+}
+
+func (route *CookieRoute) Route(requested http.RequestMessage) http.Request {
+	return nil
+}

--- a/playground/cookie_route.go
+++ b/playground/cookie_route.go
@@ -114,11 +114,11 @@ func singleHeader(message http.RequestMessage, field string) (value string, err 
 	values := message.HeaderValues(field)
 	switch len(values) {
 	case 0:
-		return "", fmt.Errorf("missing type parameter")
+		return "", &missingValueError{what: field}
 	case 1:
 		return values[0], nil
 	default:
-		return "", fmt.Errorf("too many type parameters")
+		return "", &tooManyValuesError{what: field}
 	}
 }
 
@@ -132,12 +132,30 @@ func singleQueryParameter(message http.RequestMessage, name string) (value strin
 
 	switch len(values) {
 	case 0:
-		return "", fmt.Errorf("missing type parameter")
+		return "", &missingValueError{what: "type parameter"}
 	case 1:
 		return values[0], nil
 	default:
-		return "", fmt.Errorf("too many type parameters")
+		return "", &tooManyValuesError{what: "type parameter"}
 	}
+}
+
+// Resulting from a lack of any value for something that needed a value
+type missingValueError struct {
+	what string
+}
+
+func (err *missingValueError) Error() string {
+	return fmt.Sprintf("no value provided for %s", err.what)
+}
+
+// Resulting from too many values for something that needed a single value
+type tooManyValuesError struct {
+	what string
+}
+
+func (err *tooManyValuesError) Error() string {
+	return fmt.Sprintf("too many values for %s", err.what)
 }
 
 // Stores information about cookies in memory

--- a/playground/cookie_route_test.go
+++ b/playground/cookie_route_test.go
@@ -109,5 +109,45 @@ var _ = Describe("CookieRegistrar", func() {
 				response.BodyShould(Equal("Eat a Snickerdoodle."))
 			})
 		})
+
+		Context("given no 'type' parameter", func() {
+			BeforeEach(func() {
+				request := &httptest.RequestMessage{
+					MethodReturns: http.GET,
+					PathReturns:   setTypePath,
+					TargetReturns: setTypePath,
+				}
+				response = invokeResourceMethod(registrar.Get, request)
+			})
+
+			It("responds 400 Bad Request", func() {
+				response.ShouldBeWellFormed()
+				response.StatusShouldBe(400, "Bad Request")
+			})
+			It("has no body", func() {
+				response.BodyShould(BeEmpty())
+			})
+		})
+
+		Context("given 2 or more 'type' parameters", func() {
+			BeforeEach(func() {
+				request := &httptest.RequestMessage{
+					MethodReturns: http.GET,
+					PathReturns:   setTypePath,
+					TargetReturns: setTypePath,
+				}
+				request.AddQueryParameter("type", "HighlanderCookie")
+				request.AddQueryParameter("type", "TheKurganCookie")
+				response = invokeResourceMethod(registrar.Get, request)
+			})
+
+			It("responds 400 Bad Request", func() {
+				response.ShouldBeWellFormed()
+				response.StatusShouldBe(400, "Bad Request")
+			})
+			It("has no body", func() {
+				response.BodyShould(BeEmpty())
+			})
+		})
 	})
 })

--- a/playground/cookie_route_test.go
+++ b/playground/cookie_route_test.go
@@ -271,19 +271,3 @@ var _ = Describe("CookieRegistrar", func() {
 		})
 	})
 })
-
-var _ = Describe("CookieLedger", func() {
-	var (
-		ledger     *playground.MemoryCookieLedger
-		preference string
-		err        error
-	)
-
-	Describe("#PreferredType", func() {
-		It("returns an error when no preference has been specified", func() {
-			preference, err = ledger.PreferredType()
-			Expect(preference).To(Equal(""))
-			Expect(err).To(MatchError("no preference has been defined"))
-		})
-	})
-})

--- a/playground/cookie_route_test.go
+++ b/playground/cookie_route_test.go
@@ -38,11 +38,6 @@ var _ = Describe("::NewCookieRoute", func() {
 		Expect(route.Registrar).NotTo(BeNil())
 		Expect(route.Registrar).To(BeAssignableToTypeOf(&playground.CookieRegistrar{}))
 	})
-
-	It("the cookie monster and the cookie registrar share the same, in-memory ledger", func() {
-		Expect(route.Monster.Ledger).To(BeEquivalentTo(&playground.MemoryCookieLedger{}))
-		Expect(route.Monster.Ledger).To(BeIdenticalTo(route.Registrar.Ledger))
-	})
 })
 
 var _ = Describe("CookieRoute", func() {
@@ -116,15 +111,13 @@ var _ = Describe("CookieRoute", func() {
 
 var _ = Describe("CookieMonster", func() {
 	var (
-		monster *playground.CookieMonster
-		//ledger   *CookieLedgerMock
+		monster  *playground.CookieMonster
 		response *httptest.ResponseMessage
 	)
 
 	Describe("#Get", func() {
 		Context("given 1 Cookie header", func() {
 			BeforeEach(func() {
-				//ledger = &CookieLedgerMock{PreferredTypeReturns: "earwax"}
 				monster = &playground.CookieMonster{}
 				request := &httptest.RequestMessage{
 					MethodReturns: http.GET,
@@ -152,7 +145,6 @@ var _ = Describe("CookieMonster", func() {
 
 		Context("given no Cookie header", func() {
 			BeforeEach(func() {
-				//ledger = &CookieLedgerMock{PreferredTypeReturns: "earwax"}
 				monster = &playground.CookieMonster{}
 				request := &httptest.RequestMessage{
 					MethodReturns: http.GET,
@@ -170,7 +162,6 @@ var _ = Describe("CookieMonster", func() {
 
 		Context("given 2 or more Cookie headers", func() {
 			BeforeEach(func() {
-				//ledger = &CookieLedgerMock{PreferredTypeReturns: "earwax"}
 				monster = &playground.CookieMonster{}
 				request := &httptest.RequestMessage{
 					MethodReturns: http.GET,

--- a/playground/cookie_route_test.go
+++ b/playground/cookie_route_test.go
@@ -17,27 +17,50 @@ const (
 )
 
 var _ = Describe("::NewCookieRoute", func() {
+	var route *playground.CookieRoute
+	BeforeEach(func() {
+		route = playground.NewCookieRoute("/set", "/read")
+	})
+
 	It("returns a Route at the given paths", func() {
-		route := playground.NewCookieRoute("/set", "/read")
 		Expect(route).NotTo(BeNil())
 		Expect(route).To(BeAssignableToTypeOf(&playground.CookieRoute{}))
 		Expect(route.SetTypePath).To(Equal("/set"))
 		Expect(route.ReadTypePath).To(Equal("/read"))
+	})
+
+	It("configures a CookieMonster", func() {
+		Expect(route.Monster).NotTo(BeNil())
+		Expect(route.Monster).To(BeAssignableToTypeOf(&playground.CookieMonster{}))
+	})
+
+	It("configures a CookieRegistrar", func() {
+		Expect(route.Registrar).NotTo(BeNil())
 		Expect(route.Registrar).To(BeAssignableToTypeOf(&playground.CookieRegistrar{}))
+	})
+
+	It("the cookie monster and the cookie registrar share the same, in-memory ledger", func() {
+		Expect(route.Monster.Ledger).To(BeEquivalentTo(&playground.MemoryCookieLedger{}))
+		Expect(route.Monster.Ledger).To(BeIdenticalTo(route.Registrar.Ledger))
 	})
 })
 
 var _ = Describe("CookieRoute", func() {
 	var (
-		router   http.Route
-		response = &bytes.Buffer{}
+		router    http.Route
+		registrar *playground.CookieRegistrar
+		monster   *playground.CookieMonster
+		response  = &bytes.Buffer{}
 	)
 
 	Describe("#Route", func() {
 		BeforeEach(func() {
 			router = &playground.CookieRoute{
-				SetTypePath:  setTypePath,
+				SetTypePath: setTypePath,
+				Registrar:   registrar,
+
 				ReadTypePath: readTypePath,
+				Monster:      monster,
 			}
 			response.Reset()
 		})
@@ -63,9 +86,70 @@ var _ = Describe("CookieRoute", func() {
 			})
 		})
 
+		Context("when the path is the configured path for reading the type of cookie", func() {
+			Context("when the method is OPTIONS", func() {
+				BeforeEach(func() {
+					requested := http.NewOptionsMessage(readTypePath)
+					routedRequest := router.Route(requested)
+					Expect(routedRequest).NotTo(BeNil())
+					routedRequest.Handle(response)
+				})
+
+				It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
+				It("allows OPTIONS", httptest.ShouldAllowMethods(response, http.OPTIONS))
+				It("allows GET", httptest.ShouldAllowMethods(response, http.GET))
+			})
+
+			It("replies Method Not Allowed on any other method", func() {
+				requested := http.NewTraceMessage(readTypePath)
+				routedRequest := router.Route(requested)
+				Expect(routedRequest).To(BeAssignableToTypeOf(clienterror.MethodNotAllowed()))
+			})
+		})
+
 		It("passes on any other path by returning nil", func() {
 			requested := http.NewGetMessage("/")
 			Expect(router.Route(requested)).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("CookieMonster", func() {
+	var (
+		monster  *playground.CookieMonster
+		response *httptest.ResponseMessage
+	)
+
+	BeforeEach(func() {
+		monster = &playground.CookieMonster{}
+	})
+
+	Describe("#Get", func() {
+		Context("when a cookie type has been registered", func() {
+			BeforeEach(func() {
+				ledger := &CookieLedgerMock{PreferredTypeReturns: "earwax"}
+				monster = &playground.CookieMonster{Ledger: ledger}
+				request := &httptest.RequestMessage{
+					MethodReturns: http.GET,
+					PathReturns:   readTypePath,
+					TargetReturns: readTypePath,
+				}
+				response = invokeResourceMethod(monster.Get, request)
+			})
+
+			It("responds 200 OK", func() {
+				response.ShouldBeWellFormed()
+				response.StatusShouldBe(200, "OK")
+			})
+			It("sets Content-Type to 'text/plain'", func() {
+				response.HeaderShould("Content-Type", Equal("text/plain"))
+			})
+			It("sets Content-Length to the number of bytes in the message body", func() {
+				Expect(response.HeaderAsInt("Content-Length")).To(BeNumerically(">", 0))
+			})
+			It("acknowledges the registration in the message body", func() {
+				response.BodyShould(Equal("mmmm earwax"))
+			})
 		})
 	})
 })
@@ -148,6 +232,22 @@ var _ = Describe("CookieRegistrar", func() {
 			It("has no body", func() {
 				response.BodyShould(BeEmpty())
 			})
+		})
+	})
+})
+
+var _ = Describe("CookieLedger", func() {
+	var (
+		ledger     *playground.MemoryCookieLedger
+		preference string
+		err        error
+	)
+
+	Describe("#PreferredType", func() {
+		It("returns an error when no preference has been specified", func() {
+			preference, err = ledger.PreferredType()
+			Expect(preference).To(Equal(""))
+			Expect(err).To(MatchError("no preference has been defined"))
 		})
 	})
 })

--- a/playground/cookie_route_test.go
+++ b/playground/cookie_route_test.go
@@ -4,19 +4,26 @@ import (
 	"bytes"
 
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/httptest"
+	"github.com/kkrull/gohttp/msg/clienterror"
 	"github.com/kkrull/gohttp/playground"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+)
+
+const (
+	setTypePath  = "/set"
+	readTypePath = "/read"
 )
 
 var _ = Describe("::NewCookieRoute", func() {
 	It("returns a Route at the given paths", func() {
 		route := playground.NewCookieRoute("/set", "/read")
 		Expect(route).NotTo(BeNil())
-		Expect(route).To(BeEquivalentTo(&playground.CookieRoute{
-			SetTypePath: "/set",
-			ReadTypePath: "/read",
-		}))
+		Expect(route).To(BeAssignableToTypeOf(&playground.CookieRoute{}))
+		Expect(route.SetTypePath).To(Equal("/set"))
+		Expect(route.ReadTypePath).To(Equal("/read"))
+		Expect(route.Registrar).To(BeAssignableToTypeOf(&playground.CookieRegistrar{}))
 	})
 })
 
@@ -29,13 +36,78 @@ var _ = Describe("CookieRoute", func() {
 	Describe("#Route", func() {
 		BeforeEach(func() {
 			router = &playground.CookieRoute{
+				SetTypePath:  setTypePath,
+				ReadTypePath: readTypePath,
 			}
 			response.Reset()
+		})
+
+		Context("when the path is the configured path for setting the type of cookie", func() {
+			Context("when the method is OPTIONS", func() {
+				BeforeEach(func() {
+					requested := http.NewOptionsMessage(setTypePath)
+					routedRequest := router.Route(requested)
+					Expect(routedRequest).NotTo(BeNil())
+					routedRequest.Handle(response)
+				})
+
+				It("responds 200 OK with no body", httptest.ShouldHaveNoBody(response, 200, "OK"))
+				It("allows OPTIONS", httptest.ShouldAllowMethods(response, http.OPTIONS))
+				It("allows GET", httptest.ShouldAllowMethods(response, http.GET))
+			})
+
+			It("replies Method Not Allowed on any other method", func() {
+				requested := http.NewTraceMessage(setTypePath)
+				routedRequest := router.Route(requested)
+				Expect(routedRequest).To(BeAssignableToTypeOf(clienterror.MethodNotAllowed()))
+			})
 		})
 
 		It("passes on any other path by returning nil", func() {
 			requested := http.NewGetMessage("/")
 			Expect(router.Route(requested)).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("CookieRegistrar", func() {
+	var (
+		registrar *playground.CookieRegistrar
+		response  *httptest.ResponseMessage
+	)
+
+	BeforeEach(func() {
+		registrar = &playground.CookieRegistrar{}
+	})
+
+	Describe("#Get", func() {
+		Context("given a 'type' query parameter", func() {
+			BeforeEach(func() {
+				request := &httptest.RequestMessage{
+					MethodReturns: http.GET,
+					PathReturns:   setTypePath,
+					TargetReturns: setTypePath,
+				}
+				request.AddQueryParameter("type", "Snickerdoodle")
+				response = invokeResourceMethod(registrar.Get, request)
+			})
+
+			It("responds 200 OK", func() {
+				response.ShouldBeWellFormed()
+				response.StatusShouldBe(200, "OK")
+			})
+			It("Sets a Set-Cookie header", func() {
+				response.HeaderShould("Set-Cookie", Not(BeEmpty()))
+			})
+			It("sets Content-Type to 'text/plain'", func() {
+				response.HeaderShould("Content-Type", Equal("text/plain"))
+			})
+			It("sets Content-Length to the number of bytes in the message body", func() {
+				Expect(response.HeaderAsInt("Content-Length")).To(BeNumerically(">", 0))
+			})
+			It("acknowledges the registration in the message body", func() {
+				response.BodyShould(Equal("Eat a Snickerdoodle."))
+			})
 		})
 	})
 })

--- a/playground/cookie_route_test.go
+++ b/playground/cookie_route_test.go
@@ -116,24 +116,22 @@ var _ = Describe("CookieRoute", func() {
 
 var _ = Describe("CookieMonster", func() {
 	var (
-		monster  *playground.CookieMonster
+		monster *playground.CookieMonster
+		//ledger   *CookieLedgerMock
 		response *httptest.ResponseMessage
 	)
 
-	BeforeEach(func() {
-		monster = &playground.CookieMonster{}
-	})
-
 	Describe("#Get", func() {
-		Context("when a cookie type has been registered", func() {
+		Context("given 1 Cookie header", func() {
 			BeforeEach(func() {
-				ledger := &CookieLedgerMock{PreferredTypeReturns: "earwax"}
-				monster = &playground.CookieMonster{Ledger: ledger}
+				//ledger = &CookieLedgerMock{PreferredTypeReturns: "earwax"}
+				monster = &playground.CookieMonster{}
 				request := &httptest.RequestMessage{
 					MethodReturns: http.GET,
 					PathReturns:   readTypePath,
 					TargetReturns: readTypePath,
 				}
+				request.AddHeader("Cookie", "earwax")
 				response = invokeResourceMethod(monster.Get, request)
 			})
 
@@ -147,8 +145,46 @@ var _ = Describe("CookieMonster", func() {
 			It("sets Content-Length to the number of bytes in the message body", func() {
 				Expect(response.HeaderAsInt("Content-Length")).To(BeNumerically(">", 0))
 			})
-			It("acknowledges the registration in the message body", func() {
+			It("expresses satisfaction for the specified type of cookie", func() {
 				response.BodyShould(Equal("mmmm earwax"))
+			})
+		})
+
+		Context("given no Cookie header", func() {
+			BeforeEach(func() {
+				//ledger = &CookieLedgerMock{PreferredTypeReturns: "earwax"}
+				monster = &playground.CookieMonster{}
+				request := &httptest.RequestMessage{
+					MethodReturns: http.GET,
+					PathReturns:   readTypePath,
+					TargetReturns: readTypePath,
+				}
+				response = invokeResourceMethod(monster.Get, request)
+			})
+
+			It("responds 400 Bad Request", func() {
+				response.ShouldBeWellFormed()
+				response.StatusShouldBe(400, "Bad Request")
+			})
+		})
+
+		Context("given 2 or more Cookie headers", func() {
+			BeforeEach(func() {
+				//ledger = &CookieLedgerMock{PreferredTypeReturns: "earwax"}
+				monster = &playground.CookieMonster{}
+				request := &httptest.RequestMessage{
+					MethodReturns: http.GET,
+					PathReturns:   readTypePath,
+					TargetReturns: readTypePath,
+				}
+				request.AddHeader("Cookie", "chocolate")
+				request.AddHeader("Cookie", "wat")
+				response = invokeResourceMethod(monster.Get, request)
+			})
+
+			It("responds 400 Bad Request", func() {
+				response.ShouldBeWellFormed()
+				response.StatusShouldBe(400, "Bad Request")
 			})
 		})
 	})

--- a/playground/cookie_route_test.go
+++ b/playground/cookie_route_test.go
@@ -1,0 +1,41 @@
+package playground_test
+
+import (
+	"bytes"
+
+	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/playground"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("::NewCookieRoute", func() {
+	It("returns a Route at the given paths", func() {
+		route := playground.NewCookieRoute("/set", "/read")
+		Expect(route).NotTo(BeNil())
+		Expect(route).To(BeEquivalentTo(&playground.CookieRoute{
+			SetTypePath: "/set",
+			ReadTypePath: "/read",
+		}))
+	})
+})
+
+var _ = Describe("CookieRoute", func() {
+	var (
+		router   http.Route
+		response = &bytes.Buffer{}
+	)
+
+	Describe("#Route", func() {
+		BeforeEach(func() {
+			router = &playground.CookieRoute{
+			}
+			response.Reset()
+		})
+
+		It("passes on any other path by returning nil", func() {
+			requested := http.NewGetMessage("/")
+			Expect(router.Route(requested)).To(BeNil())
+		})
+	})
+})

--- a/playground/playground_suite_test.go
+++ b/playground/playground_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kkrull/gohttp/http"
+	"github.com/kkrull/gohttp/httptest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -98,6 +99,14 @@ func (mock *ReadWriteResourceMock) PutShouldHaveBeenCalled() {
 }
 
 /* Helpers */
+
+func invokeResourceMethod(invokeMethod httpResourceMethod, request http.RequestMessage) *httptest.ResponseMessage {
+	response := &bytes.Buffer{}
+	invokeMethod(response, request)
+	return httptest.ParseResponse(response)
+}
+
+type httpResourceMethod = func(io.Writer, http.RequestMessage)
 
 func handleRequest(router http.Route, method, path string) {
 	requested := http.NewRequestMessage(method, path)

--- a/playground/playground_suite_test.go
+++ b/playground/playground_suite_test.go
@@ -16,16 +16,6 @@ func TestPlayground(t *testing.T) {
 	RunSpecs(t, "playground")
 }
 
-/* CookieLedgerMock */
-
-type CookieLedgerMock struct {
-	PreferredTypeReturns string
-}
-
-func (mock *CookieLedgerMock) PreferredType() (string, error) {
-	return mock.PreferredTypeReturns, nil
-}
-
 /* ParameterReporterMock */
 
 type ParameterReporterMock struct{}

--- a/playground/playground_suite_test.go
+++ b/playground/playground_suite_test.go
@@ -16,6 +16,16 @@ func TestPlayground(t *testing.T) {
 	RunSpecs(t, "playground")
 }
 
+/* CookieLedgerMock */
+
+type CookieLedgerMock struct {
+	PreferredTypeReturns string
+}
+
+func (mock *CookieLedgerMock) PreferredType() (string, error) {
+	return mock.PreferredTypeReturns, nil
+}
+
 /* ParameterReporterMock */
 
 type ParameterReporterMock struct{}

--- a/playground/singleton_route_test.go
+++ b/playground/singleton_route_test.go
@@ -2,7 +2,6 @@ package playground_test
 
 import (
 	"bytes"
-	"io"
 
 	"github.com/kkrull/gohttp/http"
 	"github.com/kkrull/gohttp/httptest"
@@ -327,11 +326,3 @@ func putRequest(path string, body string) *httptest.RequestMessage {
 	request.SetStringBody(body)
 	return request
 }
-
-func invokeResourceMethod(invokeMethod httpResourceMethod, request http.RequestMessage) *httptest.ResponseMessage {
-	response := &bytes.Buffer{}
-	invokeMethod(response, request)
-	return httptest.ParseResponse(response)
-}
-
-type httpResourceMethod = func(io.Writer, http.RequestMessage)


### PR DESCRIPTION
Enough to get `CookieData` to pass.

## Summary of changes

Added a `playground.CookieRoute` to

* register a cookie type with `/cookie?type=<type>`, which responds with `Set-Cookie`
* consume that cookie with `/eat_cookie` with a `Cookie` header
