### PR TITLE
Concurrent requests

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -7,28 +7,42 @@ import (
 	"net"
 )
 
-func MakeTCPServerOnAvailablePort(host string) *TCPServer {
-	return &TCPServer{
-		Host:    host,
-		Port:    0,
-		Handler: NewConnectionHandler(NewRouter()),
+// Builder for TCPServer that defaults to any available port on localhost
+func TCPServerBuilder(host string) *tcpServerBuilder {
+	return &tcpServerBuilder{
+		host:    host,
+		port:    0,
+		handler: NewConnectionHandler(NewRouter()),
 	}
 }
 
-func MakeTCPServer(host string, port uint16) *TCPServer {
+type tcpServerBuilder struct {
+	host    string
+	port    uint16
+	handler ConnectionHandler
+}
+
+func (builder *tcpServerBuilder) Build() *TCPServer {
 	return &TCPServer{
-		Host:    host,
-		Port:    port,
-		Handler: NewConnectionHandler(NewRouter()),
+		Host:    builder.host,
+		Port:    builder.port,
+		Handler: builder.handler,
 	}
 }
 
-func MakeTCPServerWithHandler(host string, port uint16, handler ConnectionHandler) *TCPServer {
-	return &TCPServer{
-		Host:    host,
-		Port:    port,
-		Handler: handler,
-	}
+func (builder *tcpServerBuilder) ListeningOnHost(host string) *tcpServerBuilder {
+	builder.host = host
+	return builder
+}
+
+func (builder *tcpServerBuilder) ListeningOnPort(port uint16) *tcpServerBuilder {
+	builder.port = port
+	return builder
+}
+
+func (builder *tcpServerBuilder) WithConnectionHandler(handler ConnectionHandler) *tcpServerBuilder {
+	builder.handler = handler
+	return builder
 }
 
 type TCPServer struct {

--- a/http/server.go
+++ b/http/server.go
@@ -10,16 +10,18 @@ import (
 // Builder for TCPServer that defaults to any available port on localhost
 func TCPServerBuilder(host string) *tcpServerBuilder {
 	return &tcpServerBuilder{
-		host:    host,
-		port:    0,
-		handler: NewConnectionHandler(NewRouter()),
+		host:           host,
+		port:           0,
+		maxConnections: 1,
+		handler:        NewConnectionHandler(NewRouter()),
 	}
 }
 
 type tcpServerBuilder struct {
-	host    string
-	port    uint16
-	handler ConnectionHandler
+	host           string
+	port           uint16
+	maxConnections uint
+	handler        ConnectionHandler
 }
 
 func (builder *tcpServerBuilder) Build() *TCPServer {
@@ -42,6 +44,11 @@ func (builder *tcpServerBuilder) ListeningOnPort(port uint16) *tcpServerBuilder 
 
 func (builder *tcpServerBuilder) WithConnectionHandler(handler ConnectionHandler) *tcpServerBuilder {
 	builder.handler = handler
+	return builder
+}
+
+func (builder *tcpServerBuilder) WithMaxConnections(maxConnections uint) *tcpServerBuilder {
+	builder.maxConnections = maxConnections //TODO KDK: ADd to TCPServer
 	return builder
 }
 

--- a/http/server.go
+++ b/http/server.go
@@ -119,11 +119,9 @@ func (server TCPServer) acceptConnections() {
 				continue
 			}
 
-			//fmt.Printf("Using token: %d\n", token)
 			go func(t uint) {
 				server.Handler.Handle(bufio.NewReader(conn), conn)
 				_ = conn.Close()
-				//fmt.Printf("Returning token: %d\n", t)
 				tokens <- t
 			}(token)
 		default:

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -10,13 +10,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var (
-	server *http.TCPServer
-	conn   net.Conn
-	err    error
-)
-
 var _ = Describe("TCPServer", func() {
+	var (
+		server *http.TCPServer
+		conn   net.Conn
+		err    error
+	)
+
 	AfterEach(func(done Done) {
 		if conn != nil {
 			Expect(conn.Close()).To(Succeed())
@@ -217,7 +217,7 @@ var _ = Describe("TCPServer", func() {
 				close(done)
 			})
 
-			FIt("can handle multiple connections at a time", func(done Done) {
+			It("can handle multiple connections at a time", func(done Done) {
 				slowConn := dial(server)
 				fastConn := dial(server)
 				writeString(fastConn, "GET / HTTP/1.1\r\n\r\n")
@@ -229,13 +229,13 @@ var _ = Describe("TCPServer", func() {
 				Expect(slowConn.Close()).To(Succeed())
 
 				close(done)
-			})
+			}, 2)
 		})
 	})
 })
 
 func dial(server *http.TCPServer) net.Conn {
-	conn, err = net.Dial("tcp", server.Address().String())
+	conn, err := net.Dial("tcp", server.Address().String())
 	Expect(err).NotTo(HaveOccurred())
 	return conn
 }

--- a/main.go
+++ b/main.go
@@ -9,8 +9,12 @@ import (
 	"github.com/kkrull/gohttp/main/cmd"
 )
 
+const maxConnections uint = 4
+
 func main() {
-	factory := &cmd.InterruptFactory{Interrupts: subscribeToSignals(os.Interrupt)}
+	factory := &cmd.InterruptFactory{
+		Interrupts:     subscribeToSignals(os.Interrupt),
+		MaxConnections: maxConnections}
 	gohttp := &GoHTTP{
 		CommandParser: factory.CliCommandParser(),
 		Stderr:        os.Stderr}

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -39,10 +39,11 @@ func (factory *InterruptFactory) RunCommand(server Server) (command CliCommand, 
 
 func (factory *InterruptFactory) TCPServer(contentRootPath string, host string, port uint16) Server {
 	router := factory.routerWithAllRoutes(contentRootPath)
-	return http.MakeTCPServerWithHandler(
-		host,
-		port,
-		http.NewConnectionHandler(router))
+	handler := http.NewConnectionHandler(router)
+	return http.TCPServerBuilder(host).
+		ListeningOnPort(port).
+		WithConnectionHandler(handler).
+		Build()
 }
 
 func (factory *InterruptFactory) routerWithAllRoutes(contentRootPath string) http.Router {

--- a/main/cmd/factory.go
+++ b/main/cmd/factory.go
@@ -13,7 +13,8 @@ import (
 )
 
 type InterruptFactory struct {
-	Interrupts <-chan os.Signal
+	Interrupts     <-chan os.Signal
+	MaxConnections uint
 }
 
 func (factory *InterruptFactory) CliCommandParser() *CliCommandParser {
@@ -43,6 +44,7 @@ func (factory *InterruptFactory) TCPServer(contentRootPath string, host string, 
 	return http.TCPServerBuilder(host).
 		ListeningOnPort(port).
 		WithConnectionHandler(handler).
+		WithMaxConnections(factory.MaxConnections).
 		Build()
 }
 

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -78,14 +78,18 @@ var _ = Describe("InterruptFactory", func() {
 
 		BeforeEach(func() {
 			interrupts = make(chan os.Signal, 1)
-			factory = &cmd.InterruptFactory{Interrupts: interrupts}
+			factory = &cmd.InterruptFactory{
+				Interrupts: interrupts,
+				MaxConnections: 42,
+			}
 
 			server = factory.TCPServer("/public", "localhost", 8421)
 			typedServer, _ = server.(*http.TCPServer)
 		})
 
-		It("returns an http.TCPServer", func() {
+		It("returns an http.TCPServer with the specified level of concurrency", func() {
 			Expect(server).To(BeAssignableToTypeOf(&http.TCPServer{}))
+			Expect(typedServer.MaxConnections).To(Equal(uint(42)))
 		})
 
 		It("has a capabilities route", func() {

--- a/main/cmd/factory_test.go
+++ b/main/cmd/factory_test.go
@@ -79,7 +79,7 @@ var _ = Describe("InterruptFactory", func() {
 		BeforeEach(func() {
 			interrupts = make(chan os.Signal, 1)
 			factory = &cmd.InterruptFactory{
-				Interrupts: interrupts,
+				Interrupts:     interrupts,
 				MaxConnections: 42,
 			}
 


### PR DESCRIPTION
Basic implementation of handling concurrent requests.  The basic idea implemented thus far is to have a channel with a fixed number of "worker tokens" in it.  In order for `http.TCPServer` to accept a connection and handle the request, it must obtain one of these tokens (by receiving from the channel), and then it spawns a goroutine to handle it.  When the request has been handled, the goroutine returns the token to the channel and exits.

There is certainly room for improvement after this, in areas such as:

1. Automated load testing with `cob_spec` and possibly also Apache Bench does not seem to be supported on OSX High Sierra.  There are a number of other products such as JMeter and `goreplay` which may be more reliable.  cURL also can be used, but in practice it's orders of magnitude slower in dispatching requests and hence does not place the same load on the server.
1. There may well be a `goroutine` pool that's implemented in the standard library or otherwise available.  I'd be happy to research more of that once everything is working.
1. The configuration defaults to a maximum of 4 concurrent requests.  The default could be tailored in relation to `GOMAXPROCS` and configurable via the command line.
